### PR TITLE
Add options to configure client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# 1.0.0, in progress
+
+## Added
+
+## Updated
+
+## Bugfixes
+
+## Removed

--- a/README.md
+++ b/README.md
@@ -3,3 +3,17 @@
 Note: This library is experimental. Do not rely on it yet.
 
 This is a programmatic interface in Go for SignalFx's metadata and ingest APIs.
+
+# Example
+
+```
+import "github.com/signalfx/signalfx-go"
+
+// The client can be customized by backing options onto the end. Check the
+// for more info!
+
+// Instantiate your own client if you want to customize it's options
+// or test with a RoundTripper
+httpClient := &http.Client{…}
+client := new Client("your-token-here", HTTPClient(httpClient))
+```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ import "github.com/signalfx/signalfx-go"
 // The client can be customized by backing options onto the end. Check the
 // for more info!
 
-// Instantiate your own client if you want to customize it's options
+// Instantiate your own client if you want to customize its options
 // or test with a RoundTripper
 httpClient := &http.Client{…}
 client := new Client("your-token-here", HTTPClient(httpClient))

--- a/client_test.go
+++ b/client_test.go
@@ -32,7 +32,7 @@ func setup() func() {
 	mux = http.NewServeMux()
 	server = httptest.NewServer(mux)
 
-	client, _ = NewClient(TestToken, server.URL)
+	client, _ = NewClient(TestToken, APIUrl(server.URL))
 
 	return func() {
 		server.Close()


### PR DESCRIPTION
# Summary

Add capability to customize client.

# Motivation

#2 from @keitwb asked about configuring the HTTP client. Such customizations are common and I've used [this pattern](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis) in the past to make friendly configuration with good defaults.

This PR adds configuration of the base API URL and the HTTP client, per @keitwb's request.