### PR TITLE
Add integration in a partial way

### DIFF
--- a/integration.go
+++ b/integration.go
@@ -1,0 +1,42 @@
+package signalfx
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+)
+
+// IntegrationAPIURL is the base URL for interacting with intergrations.
+const IntegrationAPIURL = "/v2/integration"
+
+// DeleteIntegration deletes an integration.
+func (c *Client) DeleteIntegration(id string) error {
+	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
+
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("Unexpected status code: " + resp.Status)
+	}
+
+	return nil
+}
+
+// GetIntegration gets a integration.
+func (c *Client) GetIntegration(id string) (*map[string]interface{}, error) {
+	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
+
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	finalIntegration := map[string]interface{}{}
+
+	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+
+	return &finalIntegration, err
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,0 +1,28 @@
+package signalfx
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeleteIntegration(t *testing.T) {
+	teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/integration/string", verifyRequest(t, "DELETE", http.StatusOK, nil, ""))
+
+	err := client.DeleteIntegration("string")
+	assert.NoError(t, err, "Unexpected error deleting integration")
+}
+
+func TestGetIntegration(t *testing.T) {
+	teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/integration/string", verifyRequest(t, "GET", http.StatusOK, nil, "integration/get_success.json"))
+
+	_, err := client.GetIntegration("string")
+	assert.NoError(t, err, "Unexpected error getting integration")
+}

--- a/testdata/fixtures/integration/get_success.json
+++ b/testdata/fixtures/integration/get_success.json
@@ -1,0 +1,17 @@
+{
+  "id": "string",
+  "created": 1556361030000,
+  "creator": "string",
+  "enabled": true,
+  "lastUpdated": 1556620230000,
+  "lastUpdatedBy": "string",
+  "name": "string",
+  "type": "Slack",
+  "method": "Webhook",
+  "webhookUrl": "string",
+  "scope": "string",
+  "slackTeamName": "string",
+  "slackTeamId": "string",
+  "slackUserId": "string",
+  "accessTokenUpdated": 1555929030000
+}


### PR DESCRIPTION
# Summary
Adds `GetIntegration` and `DeleteIntegration`. These are needed for the Terraform provider's testing.

# Motivation
We need to verify that Integrations are created correctly. The content can be all over the map, so we'll defer that for now.