### PR TITLE
Adjust type of source's value, can be string or slice

### DIFF
--- a/dashboard/model_charts_single_filter.go
+++ b/dashboard/model_charts_single_filter.go
@@ -16,6 +16,6 @@ type ChartsSingleFilter struct {
 	// Name of the dimension or custom property to match to the data.<br> **Note:** If the dimension or custom property doesn't exist in any of the charts for the dashboard, and `ChartsFilterObject.NOT` is `true`, the system doesn't display any data in the charts.
 	Property string `json:"property"`
 	// A list of values to compare to the value of the dimension or custom property specified in `ChartsFilterObject.property`. If the list contains more than one value, the filter becomes a set of queries between the value of `property` and each element of `value`. The system joins these queries with an implicit OR.
-	Value         string `json:"value"`
-	ApplyIfExists bool   `json:"applyIfExists,omitempty"`
+	Value         StringOrSlice `json:"value"`
+	ApplyIfExists bool          `json:"applyIfExists,omitempty"`
 }

--- a/dashboard/model_event_overlay_filter.go
+++ b/dashboard/model_event_overlay_filter.go
@@ -16,5 +16,5 @@ type EventOverlayFilter struct {
 	// The custom property or dimension name that provides the value to test in the filter.<br> If the name you specify isn't defined in one or more of the events associated with the dashboard, the filter never matches anything. If the `NOT` property for this filter is set to `true` and the filter never matches, all event overlays are suppressed.
 	Property string `json:"property"`
 	// An array of values to test against the specified property. If any of the values match, the system includes the event.<br> **Note:** You must specify at least one element.
-	Value string `json:"value"`
+	Value StringOrSlice `json:"value"`
 }

--- a/dashboard/string_or_slice.go
+++ b/dashboard/string_or_slice.go
@@ -1,0 +1,22 @@
+package dashboard
+
+import "encoding/json"
+
+// StringOrSlice is a slice of strings that might be just a single
+// string in JSON. e.g. if the value is "foo" we want to make it ["foo"]
+type StringOrSlice []string
+
+// UnmarshalJSON handles the decision of this being a string or slice
+// and unmarshaling accordingly.
+func (sos *StringOrSlice) UnmarshalJSON(b []byte) error {
+	if b[0] == '"' {
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		*sos = StringOrSlice([]string{s})
+	} else {
+		return json.Unmarshal(b, (*[]string)(sos))
+	}
+	return nil
+}

--- a/testdata/fixtures/dashboard/search_success.json
+++ b/testdata/fixtures/dashboard/search_success.json
@@ -39,7 +39,9 @@
             {
               "NOT": false,
               "property": "string",
-              "value": "string"
+              "value": [
+                "string"
+              ]
             }
           ]
         }
@@ -49,7 +51,9 @@
           {
             "NOT": false,
             "property": "string",
-            "value": "string"
+            "value": [
+              "string"
+            ]
           }
         ],
         "time": {
@@ -88,7 +92,9 @@
             {
               "NOT": false,
               "property": "string",
-              "value": "string"
+              "value": [
+                "string"
+              ]
             }
           ]
         }


### PR DESCRIPTION
# Summary

Implements a custom JSON unmarshaller for `source.value`.

# Motivation

In #21 I "fixed" the problem in #18. Turns out it can be either a string or an array of strings. The API documentation doesn't state this, but after doing some digging I found it in the API source.

# Notes

I left in a string *and* an array of strings version to qualify that this does the job.
