### PR TITLE
Add dashboardConfigs support to dashboard groups

### DIFF
--- a/dashboard_group/model_dashboard_config.go
+++ b/dashboard_group/model_dashboard_config.go
@@ -1,0 +1,9 @@
+package dashboard_group
+
+type DashboardConfig struct {
+	ConfigId            string  `json:"configId,omitempty"`
+	DashboardId         string  `json:"dashboardId,omitempty"`
+	DescriptionOverride string  `json:"descriptionOverride,omitempty"`
+	FiltersOverride     Filters `json:"filters,omitempty"`
+	NameOverride        string  `json:"nameOverride,omitempty"`
+}

--- a/dashboard_group/model_dashboard_group.go
+++ b/dashboard_group/model_dashboard_group.go
@@ -14,7 +14,8 @@ type DashboardGroup struct {
 	// The dashboard group creation date and time, in the form of a Unix time value (milliseconds since the Unix epoch 1970-01-01 00:00:00 UTC+0). The system sets this value, and you can't modify it.
 	Created int64 `json:"created,omitempty"`
 	// SignalFx-assigned user ID of the user that created the dashboard group. If the system created this dashboard group, the value is \"AAAAAAAAAA\". The system sets this value, and you can't modify it.
-	Creator string `json:"creator,omitempty"`
+	Creator          string             `json:"creator,omitempty"`
+	DashboardConfigs []*DashboardConfig `json:"dashboardConfigs,omitempty"`
 	// Array of dashboard IDs. The system adds the specified dashboards to the dashboard group you're creating. If you omit the property, the system creates a new dashboard and assigns it to the new dashboard group.
 	Dashboards []string `json:"dashboards,omitempty"`
 	// Description of the dashboard group. This value appears in the tooltip for the dashboard group on the Dashboards page in the web UI.

--- a/testdata/fixtures/dashboardgroup/create_success.json
+++ b/testdata/fixtures/dashboardgroup/create_success.json
@@ -12,10 +12,40 @@
   "dashboards": [
     "string"
   ],
+  "dashboardConfigs": [
+    {
+      "configId": "string",
+      "dashboardId": "string",
+      "descriptionOverride": "string",
+      "filtersOverride": {
+        "sources": [
+          {
+            "NOT": false,
+            "property": "string",
+            "values": [
+              "string"
+            ]
+          }
+        ],
+        "variables": [
+          {
+            "preferredSuggestions": null,
+            "property": "string",
+            "value": [
+              "string"
+            ]
+          }
+        ]
+      },
+      "nameOverride": null
+    }
+  ],
   "description": "string",
   "id": "string",
   "lastUpdated": 0,
   "lastUpdatedBy": "string",
   "name": "string",
-  "teams": null
+  "teams": [
+    "string"
+  ]
 }

--- a/testdata/fixtures/dashboardgroup/get_success.json
+++ b/testdata/fixtures/dashboardgroup/get_success.json
@@ -12,10 +12,40 @@
   "dashboards": [
     "string"
   ],
+  "dashboardConfigs": [
+    {
+      "configId": "string",
+      "dashboardId": "string",
+      "descriptionOverride": "string",
+      "filtersOverride": {
+        "sources": [
+          {
+            "NOT": false,
+            "property": "string",
+            "values": [
+              "string"
+            ]
+          }
+        ],
+        "variables": [
+          {
+            "preferredSuggestions": null,
+            "property": "string",
+            "value": [
+              "string"
+            ]
+          }
+        ]
+      },
+      "nameOverride": null
+    }
+  ],
   "description": "string",
   "id": "string",
   "lastUpdated": 0,
   "lastUpdatedBy": "string",
   "name": "string",
-  "teams": null
+  "teams": [
+    "string"
+  ]
 }

--- a/testdata/fixtures/dashboardgroup/update_success.json
+++ b/testdata/fixtures/dashboardgroup/update_success.json
@@ -12,10 +12,40 @@
   "dashboards": [
     "string"
   ],
+  "dashboardConfigs": [
+    {
+      "configId": "string",
+      "dashboardId": "string",
+      "descriptionOverride": "string",
+      "filtersOverride": {
+        "sources": [
+          {
+            "NOT": false,
+            "property": "string",
+            "values": [
+              "string"
+            ]
+          }
+        ],
+        "variables": [
+          {
+            "preferredSuggestions": null,
+            "property": "string",
+            "value": [
+              "string"
+            ]
+          }
+        ]
+      },
+      "nameOverride": null
+    }
+  ],
   "description": "string",
   "id": "string",
   "lastUpdated": 0,
   "lastUpdatedBy": "string",
   "name": "string",
-  "teams": null
+  "teams": [
+    "string"
+  ]
 }


### PR DESCRIPTION
# Summary

Adds `dashboardConfigs` to DashboardGroup.

# Motivation

Needed for setting up mirrored dashboards.