### PR TITLE
Remove credentialName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Removed
 
+* Removed `credentialName` from OpsGenie notifications, not a real field in the API.
 
 # 1.2.0, 2019-07-16
 

--- a/team/model_opsgenie_notification.go
+++ b/team/model_opsgenie_notification.go
@@ -15,8 +15,6 @@ type OpsgenieNotification struct {
 	Type string `json:"type"`
 	// Opsgenie-supplied credential ID that SignalFx uses to authenticate the notification with the Opsgenie system. Get this value from your Opsgenie account settings.
 	CredentialId string `json:"credentialId"`
-	// Descriptive name for the Opsgenie credential
-	CredentialName string `json:"credentialName,omitempty"`
 	// Name of an Opsgenie entity to which SignalFx assigns the alert<br> **NOTE:**<br> Specify either `responderName` or `responderId`, but not both.
 	ResponderName string `json:"responderName,omitempty"`
 	// ID of an Opsgenie entity to which SignalFx assigns the alert<br> **NOTE:**<br> Specify either `responderId` or `responderName`, but not both.

--- a/testdata/fixtures/team/create_success.json
+++ b/testdata/fixtures/team/create_success.json
@@ -28,7 +28,6 @@
       {
         "type": "OpsGenie",
         "credentialId": "string",
-        "credentialName": "string",
         "responderName": "string",
         "responderId": "string",
         "responderType": "string"

--- a/testdata/fixtures/team/get_success.json
+++ b/testdata/fixtures/team/get_success.json
@@ -28,7 +28,6 @@
       {
         "type": "OpsGenie",
         "credentialId": "string",
-        "credentialName": "string",
         "responderName": "string",
         "responderId": "string",
         "responderType": "string"

--- a/testdata/fixtures/team/search_success.json
+++ b/testdata/fixtures/team/search_success.json
@@ -31,7 +31,6 @@
           {
             "type": "OpsGenie",
             "credentialId": "string",
-            "credentialName": "string",
             "responderName": "string",
             "responderId": "string",
             "responderType": "string"

--- a/testdata/fixtures/team/update_success.json
+++ b/testdata/fixtures/team/update_success.json
@@ -28,7 +28,6 @@
       {
         "type": "OpsGenie",
         "credentialId": "string",
-        "credentialName": "string",
         "responderName": "string",
         "responderId": "string",
         "responderType": "string"


### PR DESCRIPTION
# Summary

Removes `credentialName` from OpsGenie

# Motivation

Not a real field!