### PR TITLE
signalflow client: Ignore keep alive events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Updated
 
 ## Bugfixes
+* Properly recognize the SignalFlow keep alive event message and ignore it.
 
 ## Removed
 

--- a/signalflow/messages/types.go
+++ b/signalflow/messages/types.go
@@ -61,7 +61,7 @@ type JSONMessage interface {
 }
 
 type BaseJSONMessage struct {
-	*BaseMessage
+	BaseMessage
 	rawMessage []byte
 	rawData    map[string]interface{}
 }
@@ -95,7 +95,7 @@ type BaseJSONChannelMessage struct {
 }
 
 func (j *BaseJSONChannelMessage) String() string {
-	return string(j.BaseJSONMessage.rawMessage)
+	return fmt.Sprintf("%s", j.BaseJSONMessage.rawMessage)
 }
 
 type TimestampedMessage struct {


### PR DESCRIPTION
Also fix handling of stringification of unknown messages so they don't panic