### PR TITLE
URL encode token names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,20 @@
-# 1.6.9, Pending
+# 1.6.10, Pending
 
 ## Added
- - New datapoint and span writer for high volume output
 
 ## Updated
 
 ## Bugfixes
 
 ## Removed
+
+# 1.6.9, 2019-12-09
+
+## Added
+ - New datapoint and span writer for high volume output
+
+## Bugfixes
+- Token operations now URL encode the name.
 
 # 1.6.8, Pending
 

--- a/orgtoken.go
+++ b/orgtoken.go
@@ -42,7 +42,8 @@ func (c *Client) CreateOrgToken(tokenRequest *orgtoken.CreateUpdateTokenRequest)
 
 // DeleteOrgToken deletes a token.
 func (c *Client) DeleteOrgToken(name string) error {
-	resp, err := c.doRequest("DELETE", TokenAPIURL+"/"+name, nil, nil)
+	encodedName := url.PathEscape(name)
+	resp, err := c.doRequest("DELETE", TokenAPIURL+"/"+encodedName, nil, nil)
 
 	if err != nil {
 		return err
@@ -59,7 +60,8 @@ func (c *Client) DeleteOrgToken(name string) error {
 
 // GetToken gets a token.
 func (c *Client) GetOrgToken(id string) (*orgtoken.Token, error) {
-	resp, err := c.doRequest("GET", TokenAPIURL+"/"+id, nil, nil)
+	encodedName := url.PathEscape(id)
+	resp, err := c.doRequest("GET", TokenAPIURL+"/"+encodedName, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +86,8 @@ func (c *Client) UpdateOrgToken(id string, tokenRequest *orgtoken.CreateUpdateTo
 		return nil, err
 	}
 
-	resp, err := c.doRequest("PUT", TokenAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	encodedName := url.PathEscape(id)
+	resp, err := c.doRequest("PUT", TokenAPIURL+"/"+encodedName, nil, bytes.NewReader(payload))
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +109,7 @@ func (c *Client) UpdateOrgToken(id string, tokenRequest *orgtoken.CreateUpdateTo
 func (c *Client) SearchOrgTokens(limit int, name string, offset int) (*orgtoken.SearchResults, error) {
 	params := url.Values{}
 	params.Add("limit", strconv.Itoa(limit))
-	params.Add("name", name)
+	params.Add("name", url.PathEscape(name))
 	params.Add("offset", strconv.Itoa(offset))
 
 	resp, err := c.doRequest("GET", TokenAPIURL, params, nil)

--- a/orgtoken_test.go
+++ b/orgtoken_test.go
@@ -46,9 +46,9 @@ func TestDeleteOrgToken(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/token/string", verifyRequest(t, "DELETE", http.StatusNoContent, nil, ""))
+	mux.HandleFunc("/v2/token/string%2Ffart", verifyRequest(t, "DELETE", http.StatusNoContent, nil, ""))
 
-	err := client.DeleteOrgToken("string")
+	err := client.DeleteOrgToken("string/fart")
 	assert.NoError(t, err, "Unexpected error deleting token")
 }
 
@@ -66,9 +66,9 @@ func TestGetOrgToken(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/token/string", verifyRequest(t, "GET", http.StatusOK, nil, "orgtoken/get_success.json"))
+	mux.HandleFunc("/v2/token/string%2Ffart", verifyRequest(t, "GET", http.StatusOK, nil, "orgtoken/get_success.json"))
 
-	result, err := client.GetOrgToken("string")
+	result, err := client.GetOrgToken("string/fart")
 	assert.NoError(t, err, "Unexpected error getting token")
 	assert.Equal(t, result.Name, "string", "Name does not match")
 }
@@ -77,9 +77,9 @@ func TestGetMissingOrgToken(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/token/string", verifyRequest(t, "GET", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/token/string%2Ffart", verifyRequest(t, "GET", http.StatusNotFound, nil, ""))
 
-	result, err := client.GetOrgToken("string")
+	result, err := client.GetOrgToken("string/fart")
 	assert.Error(t, err, "Should have gotten an error from a missing token")
 	assert.Nil(t, result, "Should have gotten a nil result from a missing token")
 }
@@ -89,11 +89,11 @@ func TestSearchOrgToken(t *testing.T) {
 	defer teardown()
 
 	limit := 10
-	name := "foo"
+	name := "foo/fart"
 	offset := 2
 	params := url.Values{}
 	params.Add("limit", strconv.Itoa(limit))
-	params.Add("name", name)
+	params.Add("name", url.PathEscape(name))
 	params.Add("offset", strconv.Itoa(offset))
 
 	mux.HandleFunc("/v2/token", verifyRequest(t, "GET", http.StatusOK, params, "orgtoken/search_success.json"))
@@ -107,9 +107,9 @@ func TestUpdateOrgToken(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/token/string", verifyRequest(t, "PUT", http.StatusOK, nil, "orgtoken/update_success.json"))
+	mux.HandleFunc("/v2/token/string%2Ffart", verifyRequest(t, "PUT", http.StatusOK, nil, "orgtoken/update_success.json"))
 
-	result, err := client.UpdateOrgToken("string", &orgtoken.CreateUpdateTokenRequest{
+	result, err := client.UpdateOrgToken("string/fart", &orgtoken.CreateUpdateTokenRequest{
 		Name: "string",
 	})
 	assert.NoError(t, err, "Unexpected error updating token")


### PR DESCRIPTION
# Summary

URL encode token names in operations.

# Motivation

Stop having 404s all over the place. This is causing the Terraform provider to re-create existing org tokens.