### PR TITLE
Added support for the Session Token API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.6.10, Pending
 
 ## Added
+- Support for creating and deleting tokens using the Session API
 
 ## Updated
 

--- a/alertmuting_test.go
+++ b/alertmuting_test.go
@@ -14,7 +14,7 @@ func TestCreateAlertMutingRule(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/alertmuting", verifyRequest(t, "POST", http.StatusCreated, nil, "alertmuting/create_success.json"))
+	mux.HandleFunc("/v2/alertmuting", verifyRequest(t, "POST", true, http.StatusCreated, nil, "alertmuting/create_success.json"))
 
 	result, err := client.CreateAlertMutingRule(&alertmuting.CreateUpdateAlertMutingRuleRequest{
 		Description: "string",
@@ -27,7 +27,7 @@ func TestCreateBadAlertMutingRule(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/alertmuting", verifyRequest(t, "POST", http.StatusBadRequest, nil, ""))
+	mux.HandleFunc("/v2/alertmuting", verifyRequest(t, "POST", true, http.StatusBadRequest, nil, ""))
 
 	result, err := client.CreateAlertMutingRule(&alertmuting.CreateUpdateAlertMutingRuleRequest{
 		Description: "string",
@@ -40,7 +40,7 @@ func TestDeleteAlertMutingRule(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/alertmuting/string", verifyRequest(t, "DELETE", http.StatusNoContent, nil, ""))
+	mux.HandleFunc("/v2/alertmuting/string", verifyRequest(t, "DELETE", true, http.StatusNoContent, nil, ""))
 
 	err := client.DeleteAlertMutingRule("string")
 	assert.NoError(t, err, "Unexpected error deleting alert muting rule")
@@ -50,7 +50,7 @@ func TestDeleteMissingAlertMutingRule(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/alertmuting", verifyRequest(t, "POST", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/alertmuting", verifyRequest(t, "POST", true, http.StatusNotFound, nil, ""))
 
 	err := client.DeleteAlertMutingRule("example")
 	assert.Error(t, err, "Should have gotten an error from a missing delete")
@@ -60,7 +60,7 @@ func TestGetAlertMutingRule(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/alertmuting/string", verifyRequest(t, "GET", http.StatusOK, nil, "alertmuting/get_success.json"))
+	mux.HandleFunc("/v2/alertmuting/string", verifyRequest(t, "GET", true, http.StatusOK, nil, "alertmuting/get_success.json"))
 
 	result, err := client.GetAlertMutingRule("string")
 	assert.NoError(t, err, "Unexpected error getting alert mutnig rule")
@@ -71,7 +71,7 @@ func TestGetMissingAlertMutingRule(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/alertmuting/string", verifyRequest(t, "GET", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/alertmuting/string", verifyRequest(t, "GET", true, http.StatusNotFound, nil, ""))
 
 	result, err := client.GetAlertMutingRule("string")
 	assert.Error(t, err, "Should have gotten an error from a missing alert muting rule")
@@ -92,7 +92,7 @@ func TestSearchAlertMutingRule(t *testing.T) {
 	params.Add("name", name)
 	params.Add("offset", strconv.Itoa(offset))
 
-	mux.HandleFunc("/v2/alertmuting", verifyRequest(t, "GET", http.StatusOK, params, "alertmuting/search_success.json"))
+	mux.HandleFunc("/v2/alertmuting", verifyRequest(t, "GET", true, http.StatusOK, params, "alertmuting/search_success.json"))
 
 	results, err := client.SearchAlertMutingRules(include, limit, name, offset)
 	assert.NoError(t, err, "Unexpected error search alert muting rule")
@@ -103,7 +103,7 @@ func TestUpdateAlertMutingRule(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/alertmuting/string", verifyRequest(t, "PUT", http.StatusOK, nil, "alertmuting/update_success.json"))
+	mux.HandleFunc("/v2/alertmuting/string", verifyRequest(t, "PUT", true, http.StatusOK, nil, "alertmuting/update_success.json"))
 
 	result, err := client.UpdateAlertMutingRule("string", &alertmuting.CreateUpdateAlertMutingRuleRequest{
 		Description: "string",
@@ -116,7 +116,7 @@ func TestUpdateMissingAlertMutingRule(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/alertmuting/string", verifyRequest(t, "PUT", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/alertmuting/string", verifyRequest(t, "PUT", true, http.StatusNotFound, nil, ""))
 
 	result, err := client.UpdateAlertMutingRule("string", &alertmuting.CreateUpdateAlertMutingRuleRequest{
 		Description: "string",

--- a/aws_cloudwatch_integration_test.go
+++ b/aws_cloudwatch_integration_test.go
@@ -12,7 +12,7 @@ func TestCreateAWSCloudWatchIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration", verifyRequest(t, "POST", http.StatusOK, nil, "integration/create_aws_success.json"))
+	mux.HandleFunc("/v2/integration", verifyRequest(t, "POST", true, http.StatusOK, nil, "integration/create_aws_success.json"))
 
 	result, err := client.CreateAWSCloudWatchIntegration(&integration.AwsCloudWatchIntegration{
 		Type: "AWSCloudWatch",
@@ -25,7 +25,7 @@ func TestGetAWSCloudWatchIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "GET", http.StatusOK, nil, "integration/create_aws_success.json"))
+	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "GET", true, http.StatusOK, nil, "integration/create_aws_success.json"))
 
 	result, err := client.GetAWSCloudWatchIntegration("id")
 	assert.NoError(t, err, "Unexpected error getting integration")
@@ -36,7 +36,7 @@ func TestUpdateAWSCloudWatchIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "PUT", http.StatusOK, nil, "integration/create_aws_success.json"))
+	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "PUT", true, http.StatusOK, nil, "integration/create_aws_success.json"))
 
 	result, err := client.UpdateAWSCloudWatchIntegration("id", &integration.AwsCloudWatchIntegration{
 		Type: "AWSCloudWatch",
@@ -49,7 +49,7 @@ func TestDeleteAWSCloudWatchIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "DELETE", http.StatusNoContent, nil, ""))
+	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "DELETE", true, http.StatusNoContent, nil, ""))
 
 	err := client.DeleteAWSCloudWatchIntegration("id")
 	assert.NoError(t, err, "Unexpected error creating integration")

--- a/azure_integration_test.go
+++ b/azure_integration_test.go
@@ -12,7 +12,7 @@ func TestCreateAzureIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration", verifyRequest(t, "POST", http.StatusOK, nil, "integration/create_azure_success.json"))
+	mux.HandleFunc("/v2/integration", verifyRequest(t, "POST", true, http.StatusOK, nil, "integration/create_azure_success.json"))
 
 	result, err := client.CreateAzureIntegration(&integration.AzureIntegration{
 		Type: "Azure",
@@ -25,7 +25,7 @@ func TestGetAzureIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "GET", http.StatusOK, nil, "integration/create_azure_success.json"))
+	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "GET", true, http.StatusOK, nil, "integration/create_azure_success.json"))
 
 	result, err := client.GetAzureIntegration("id")
 	assert.NoError(t, err, "Unexpected error getting integration")
@@ -36,7 +36,7 @@ func TestUpdateAzureIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "PUT", http.StatusOK, nil, "integration/create_azure_success.json"))
+	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "PUT", true, http.StatusOK, nil, "integration/create_azure_success.json"))
 
 	result, err := client.UpdateAzureIntegration("id", &integration.AzureIntegration{
 		Type: "Azure",
@@ -49,7 +49,7 @@ func TestDeleteAzureIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "DELETE", http.StatusNoContent, nil, ""))
+	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "DELETE", true, http.StatusNoContent, nil, ""))
 
 	err := client.DeleteAzureIntegration("id")
 	assert.NoError(t, err, "Unexpected error creating integration")

--- a/chart_test.go
+++ b/chart_test.go
@@ -14,7 +14,7 @@ func TestCreateChart(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/chart", verifyRequest(t, "POST", http.StatusOK, nil, "chart/create_success.json"))
+	mux.HandleFunc("/v2/chart", verifyRequest(t, "POST", true, http.StatusOK, nil, "chart/create_success.json"))
 
 	result, err := client.CreateChart(&chart.CreateUpdateChartRequest{
 		Name: "string",
@@ -27,7 +27,7 @@ func TestBadCreateChart(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/chart", verifyRequest(t, "POST", http.StatusBadRequest, nil, ""))
+	mux.HandleFunc("/v2/chart", verifyRequest(t, "POST", true, http.StatusBadRequest, nil, ""))
 
 	result, err := client.CreateChart(&chart.CreateUpdateChartRequest{
 		Name: "string",
@@ -40,7 +40,7 @@ func TestDeleteChart(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/chart/string", verifyRequest(t, "DELETE", http.StatusOK, nil, ""))
+	mux.HandleFunc("/v2/chart/string", verifyRequest(t, "DELETE", true, http.StatusOK, nil, ""))
 
 	err := client.DeleteChart("string")
 	assert.NoError(t, err, "Unexpected error deleting chart")
@@ -50,7 +50,7 @@ func TestDeleteMissingChart(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/chart/string", verifyRequest(t, "DELETE", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/chart/string", verifyRequest(t, "DELETE", true, http.StatusNotFound, nil, ""))
 
 	err := client.DeleteChart("string")
 	assert.Error(t, err, "Expected error deleting missing chart")
@@ -60,7 +60,7 @@ func TestGetChart(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/chart/string", verifyRequest(t, "GET", http.StatusOK, nil, "chart/get_success.json"))
+	mux.HandleFunc("/v2/chart/string", verifyRequest(t, "GET", true, http.StatusOK, nil, "chart/get_success.json"))
 
 	result, err := client.GetChart("string")
 	assert.NoError(t, err, "Unexpected error getting chart")
@@ -71,7 +71,7 @@ func TestGetMissingChart(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/chart/string", verifyRequest(t, "GET", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/chart/string", verifyRequest(t, "GET", true, http.StatusNotFound, nil, ""))
 
 	result, err := client.GetChart("string")
 	assert.Error(t, err, "Expected error getting missing chart")
@@ -92,7 +92,7 @@ func TestSearchChart(t *testing.T) {
 	params.Add("offset", strconv.Itoa(offset))
 	params.Add("tags", tags)
 
-	mux.HandleFunc("/v2/chart", verifyRequest(t, "GET", http.StatusOK, params, "chart/search_success.json"))
+	mux.HandleFunc("/v2/chart", verifyRequest(t, "GET", true, http.StatusOK, params, "chart/search_success.json"))
 
 	results, err := client.SearchCharts(limit, name, offset, tags)
 	assert.NoError(t, err, "Unexpected error search chart")
@@ -103,7 +103,7 @@ func TestUpdateChart(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/chart/string", verifyRequest(t, "PUT", http.StatusOK, nil, "chart/update_success.json"))
+	mux.HandleFunc("/v2/chart/string", verifyRequest(t, "PUT", true, http.StatusOK, nil, "chart/update_success.json"))
 
 	result, err := client.UpdateChart("string", &chart.CreateUpdateChartRequest{
 		Name: "string",
@@ -116,7 +116,7 @@ func TestUpdateMissingChart(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/chart/string", verifyRequest(t, "PUT", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/chart/string", verifyRequest(t, "PUT", true, http.StatusNotFound, nil, ""))
 
 	result, err := client.UpdateChart("string", &chart.CreateUpdateChartRequest{
 		Name: "string",

--- a/client.go
+++ b/client.go
@@ -81,7 +81,9 @@ func (c *Client) doRequestWithToken(method string, path string, params url.Value
 		destURL.RawQuery = params.Encode()
 	}
 	req, err := http.NewRequest(method, destURL.String(), body)
-	req.Header.Set(AuthHeaderKey, token)
+	if token != "" {
+		req.Header.Set(AuthHeaderKey, token)
+	}
 	req.Header.Set("Content-Type", "application/json")
 	if err != nil {
 		return nil, err

--- a/client.go
+++ b/client.go
@@ -67,6 +67,10 @@ func HTTPClient(httpClient *http.Client) ClientParam {
 }
 
 func (c *Client) doRequest(method string, path string, params url.Values, body io.Reader) (*http.Response, error) {
+	return c.doRequestWithToken(method, path, params, body, c.authToken)
+}
+
+func (c *Client) doRequestWithToken(method string, path string, params url.Values, body io.Reader, token string) (*http.Response, error) {
 	destURL, err := url.Parse(c.baseURL)
 	if err != nil {
 		return nil, err
@@ -77,7 +81,7 @@ func (c *Client) doRequest(method string, path string, params url.Values, body i
 		destURL.RawQuery = params.Encode()
 	}
 	req, err := http.NewRequest(method, destURL.String(), body)
-	req.Header.Set(AuthHeaderKey, c.authToken)
+	req.Header.Set(AuthHeaderKey, token)
 	req.Header.Set("Content-Type", "application/json")
 	if err != nil {
 		return nil, err

--- a/client_test.go
+++ b/client_test.go
@@ -39,12 +39,14 @@ func setup() func() {
 }
 
 // TODO: Use HTTPSuccess from testify?
-func verifyRequest(t *testing.T, method string, status int, params url.Values, resultPath string) func(w http.ResponseWriter, r *http.Request) {
+func verifyRequest(t *testing.T, method string, expectToken bool, status int, params url.Values, resultPath string) (func(w http.ResponseWriter, r *http.Request)) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if val, ok := r.Header[AuthHeaderKey]; ok {
 			assert.Equal(t, []string{TestToken}, val, "Incorrect auth token in headers")
 		} else {
-			assert.Fail(t, "Failed to find auth token in headers")
+			if expectToken {
+				assert.Fail(t, "Failed to find auth token in headers")
+			}
 		}
 
 		if val, ok := r.Header["Content-Type"]; ok {

--- a/dashboard_test.go
+++ b/dashboard_test.go
@@ -14,7 +14,7 @@ func TestCreateDashboard(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/dashboard", verifyRequest(t, "POST", http.StatusOK, nil, "dashboard/create_success.json"))
+	mux.HandleFunc("/v2/dashboard", verifyRequest(t, "POST", true, http.StatusOK, nil, "dashboard/create_success.json"))
 
 	result, err := client.CreateDashboard(&dashboard.CreateUpdateDashboardRequest{
 		Name: "string",
@@ -27,7 +27,7 @@ func TestCreateBadDashboard(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/dashboard", verifyRequest(t, "POST", http.StatusBadRequest, nil, ""))
+	mux.HandleFunc("/v2/dashboard", verifyRequest(t, "POST", true, http.StatusBadRequest, nil, ""))
 
 	result, err := client.CreateDashboard(&dashboard.CreateUpdateDashboardRequest{
 		Name: "string",
@@ -40,7 +40,7 @@ func TestDeleteDashboard(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/dashboard/string", verifyRequest(t, "DELETE", http.StatusOK, nil, ""))
+	mux.HandleFunc("/v2/dashboard/string", verifyRequest(t, "DELETE", true, http.StatusOK, nil, ""))
 
 	err := client.DeleteDashboard("string")
 	assert.NoError(t, err, "Unexpected error deleting dashboard")
@@ -50,7 +50,7 @@ func TestDeleteMissingDashboard(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/dashboard/string", verifyRequest(t, "DELETE", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/dashboard/string", verifyRequest(t, "DELETE", true, http.StatusNotFound, nil, ""))
 
 	err := client.DeleteDashboard("string")
 	assert.Error(t, err, "Should have gotten an error code for a missing dashboard")
@@ -60,7 +60,7 @@ func TestGetDashboard(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/dashboard/string", verifyRequest(t, "GET", http.StatusOK, nil, "dashboard/get_success.json"))
+	mux.HandleFunc("/v2/dashboard/string", verifyRequest(t, "GET", true, http.StatusOK, nil, "dashboard/get_success.json"))
 
 	result, err := client.GetDashboard("string")
 	assert.NoError(t, err, "Unexpected error getting dashboard")
@@ -71,7 +71,7 @@ func TestGetMissingDashboard(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/dashboard/string", verifyRequest(t, "GET", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/dashboard/string", verifyRequest(t, "GET", true, http.StatusNotFound, nil, ""))
 
 	result, err := client.GetDashboard("string")
 	assert.Error(t, err, "Expected error getting missing dashboard")
@@ -92,7 +92,7 @@ func TestSearchDashboard(t *testing.T) {
 	params.Add("offset", strconv.Itoa(offset))
 	params.Add("tags", tags)
 
-	mux.HandleFunc("/v2/dashboard", verifyRequest(t, "GET", http.StatusOK, params, "dashboard/search_success.json"))
+	mux.HandleFunc("/v2/dashboard", verifyRequest(t, "GET", true, http.StatusOK, params, "dashboard/search_success.json"))
 
 	results, err := client.SearchDashboard(limit, name, offset, tags)
 	assert.NoError(t, err, "Unexpected error search dashboard")
@@ -103,7 +103,7 @@ func TestUpdateDashboard(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/dashboard/string", verifyRequest(t, "PUT", http.StatusOK, nil, "dashboard/update_success.json"))
+	mux.HandleFunc("/v2/dashboard/string", verifyRequest(t, "PUT", true, http.StatusOK, nil, "dashboard/update_success.json"))
 
 	result, err := client.UpdateDashboard("string", &dashboard.CreateUpdateDashboardRequest{
 		Name: "string",
@@ -116,7 +116,7 @@ func TestUpdateMissingDashboard(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/dashboard/string", verifyRequest(t, "PUT", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/dashboard/string", verifyRequest(t, "PUT", true, http.StatusNotFound, nil, ""))
 
 	result, err := client.UpdateDashboard("string", &dashboard.CreateUpdateDashboardRequest{
 		Name: "string",

--- a/dashboardgroup_test.go
+++ b/dashboardgroup_test.go
@@ -16,7 +16,7 @@ func TestCreateDashboardGroup(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/dashboardgroup", verifyRequest(t, "POST", http.StatusOK, nil, "dashboardgroup/create_success.json"))
+	mux.HandleFunc("/v2/dashboardgroup", verifyRequest(t, "POST", true, http.StatusOK, nil, "dashboardgroup/create_success.json"))
 
 	result, err := client.CreateDashboardGroup(&dashboard_group.CreateUpdateDashboardGroupRequest{
 		Name: "string",
@@ -32,7 +32,7 @@ func TestCreateEmptyDashboardGroup(t *testing.T) {
 	params := url.Values{}
 	params.Add("empty", "true")
 
-	mux.HandleFunc("/v2/dashboardgroup", verifyRequest(t, "POST", http.StatusOK, params, "dashboardgroup/create_success.json"))
+	mux.HandleFunc("/v2/dashboardgroup", verifyRequest(t, "POST", true, http.StatusOK, params, "dashboardgroup/create_success.json"))
 
 	result, err := client.CreateDashboardGroup(&dashboard_group.CreateUpdateDashboardGroupRequest{
 		Name: "string",
@@ -45,7 +45,7 @@ func TestCreateBadDashboardGroup(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/dashboardgroup", verifyRequest(t, "POST", http.StatusBadRequest, nil, ""))
+	mux.HandleFunc("/v2/dashboardgroup", verifyRequest(t, "POST", true, http.StatusBadRequest, nil, ""))
 
 	result, err := client.CreateDashboardGroup(&dashboard_group.CreateUpdateDashboardGroupRequest{
 		Name: "string",
@@ -58,7 +58,7 @@ func TestDeleteDashboardGroup(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/dashboardgroup/string", verifyRequest(t, "DELETE", http.StatusNoContent, nil, ""))
+	mux.HandleFunc("/v2/dashboardgroup/string", verifyRequest(t, "DELETE", true, http.StatusNoContent, nil, ""))
 
 	err := client.DeleteDashboardGroup("string")
 	assert.NoError(t, err, "Unexpected error getting dashboard group")
@@ -68,7 +68,7 @@ func TestDeleteMissingDashboardGroup(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/dashboardgroup/string", verifyRequest(t, "DELETE", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/dashboardgroup/string", verifyRequest(t, "DELETE", true, http.StatusNotFound, nil, ""))
 
 	err := client.DeleteDashboardGroup("string")
 	assert.Error(t, err, "Should get an error getting missing dashboard group")
@@ -78,7 +78,7 @@ func TestGetDashboardGroup(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/dashboardgroup/string", verifyRequest(t, "GET", http.StatusOK, nil, "dashboardgroup/get_success.json"))
+	mux.HandleFunc("/v2/dashboardgroup/string", verifyRequest(t, "GET", true, http.StatusOK, nil, "dashboardgroup/get_success.json"))
 
 	result, err := client.GetDashboardGroup("string")
 	assert.NoError(t, err, "Unexpected error getting dashboard group")
@@ -89,7 +89,7 @@ func TestGetMissingDashboardGroup(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/dashboardgroup/string", verifyRequest(t, "GET", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/dashboardgroup/string", verifyRequest(t, "GET", true, http.StatusNotFound, nil, ""))
 
 	result, err := client.GetDashboardGroup("string")
 	assert.Error(t, err, "Should get error getting missing dashboard group")
@@ -108,7 +108,7 @@ func TestSearchDashboardGroup(t *testing.T) {
 	params.Add("name", name)
 	params.Add("offset", strconv.Itoa(offset))
 
-	mux.HandleFunc("/v2/dashboardgroup", verifyRequest(t, "GET", http.StatusOK, params, "dashboardgroup/search_success.json"))
+	mux.HandleFunc("/v2/dashboardgroup", verifyRequest(t, "GET", true, http.StatusOK, params, "dashboardgroup/search_success.json"))
 
 	results, err := client.SearchDashboardGroups(limit, name, offset)
 	assert.NoError(t, err, "Unexpected error search dashboard group")
@@ -119,7 +119,7 @@ func TestUpdateDashboardGroup(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/dashboardgroup/string", verifyRequest(t, "PUT", http.StatusBadRequest, nil, ""))
+	mux.HandleFunc("/v2/dashboardgroup/string", verifyRequest(t, "PUT", true, http.StatusBadRequest, nil, ""))
 
 	result, err := client.UpdateDashboardGroup("string", &dashboard_group.CreateUpdateDashboardGroupRequest{
 		Name: "string",

--- a/detector_test.go
+++ b/detector_test.go
@@ -14,7 +14,7 @@ func TestCreateDetector(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/detector", verifyRequest(t, "POST", http.StatusOK, nil, "detector/create_success.json"))
+	mux.HandleFunc("/v2/detector", verifyRequest(t, "POST", true, http.StatusOK, nil, "detector/create_success.json"))
 
 	result, err := client.CreateDetector(&detector.CreateUpdateDetectorRequest{
 		Name: "string",
@@ -27,7 +27,7 @@ func TestCreateBadDetector(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/detector", verifyRequest(t, "POST", http.StatusBadRequest, nil, ""))
+	mux.HandleFunc("/v2/detector", verifyRequest(t, "POST", true, http.StatusBadRequest, nil, ""))
 
 	result, err := client.CreateDetector(&detector.CreateUpdateDetectorRequest{
 		Name: "string",
@@ -40,7 +40,7 @@ func TestDeleteDetector(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/detector/string", verifyRequest(t, "DELETE", http.StatusNoContent, nil, ""))
+	mux.HandleFunc("/v2/detector/string", verifyRequest(t, "DELETE", true, http.StatusNoContent, nil, ""))
 
 	err := client.DeleteDetector("string")
 	assert.NoError(t, err, "Unexpected error deleting detector")
@@ -50,7 +50,7 @@ func TestDeleteMissingDetector(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/detector", verifyRequest(t, "POST", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/detector", verifyRequest(t, "POST", true, http.StatusNotFound, nil, ""))
 
 	err := client.DeleteDetector("example")
 	assert.Error(t, err, "Should have gotten an error from a missing delete")
@@ -60,7 +60,7 @@ func TestDisableDetector(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/detector/string/disable", verifyRequest(t, "PUT", http.StatusNoContent, nil, ""))
+	mux.HandleFunc("/v2/detector/string/disable", verifyRequest(t, "PUT", true, http.StatusNoContent, nil, ""))
 
 	err := client.DisableDetector("string", []string{"example"})
 	assert.NoError(t, err, "Unexpected error disabling detector")
@@ -70,7 +70,7 @@ func TestDisableMissingDetector(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/detector/string/disable", verifyRequest(t, "PUT", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/detector/string/disable", verifyRequest(t, "PUT", true, http.StatusNotFound, nil, ""))
 
 	err := client.DisableDetector("string", []string{"example"})
 	assert.Error(t, err, "Should have gotten an error from a missing disable")
@@ -80,7 +80,7 @@ func TestEnableDetector(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/detector/string/enable", verifyRequest(t, "PUT", http.StatusNoContent, nil, ""))
+	mux.HandleFunc("/v2/detector/string/enable", verifyRequest(t, "PUT", true, http.StatusNoContent, nil, ""))
 
 	err := client.EnableDetector("string", []string{"example"})
 	assert.NoError(t, err, "Unexpected error disabling detector")
@@ -90,7 +90,7 @@ func TestEnableMissingDetector(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/detector/string/enable", verifyRequest(t, "PUT", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/detector/string/enable", verifyRequest(t, "PUT", true, http.StatusNotFound, nil, ""))
 
 	err := client.EnableDetector("string", []string{"example"})
 	assert.Error(t, err, "Should have gotten an error from a missing enable")
@@ -100,7 +100,7 @@ func TestGetDetector(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/detector/string", verifyRequest(t, "GET", http.StatusOK, nil, "detector/get_success.json"))
+	mux.HandleFunc("/v2/detector/string", verifyRequest(t, "GET", true, http.StatusOK, nil, "detector/get_success.json"))
 
 	result, err := client.GetDetector("string")
 	assert.NoError(t, err, "Unexpected error getting detector")
@@ -111,7 +111,7 @@ func TestGetMissingDetector(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/detector/string", verifyRequest(t, "GET", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/detector/string", verifyRequest(t, "GET", true, http.StatusNotFound, nil, ""))
 
 	result, err := client.GetDetector("string")
 	assert.Error(t, err, "Should have gotten an error from a missing detector")
@@ -132,7 +132,7 @@ func TestSearchDetector(t *testing.T) {
 	params.Add("offset", strconv.Itoa(offset))
 	params.Add("tags", tags)
 
-	mux.HandleFunc("/v2/detector", verifyRequest(t, "GET", http.StatusOK, params, "detector/search_success.json"))
+	mux.HandleFunc("/v2/detector", verifyRequest(t, "GET", true, http.StatusOK, params, "detector/search_success.json"))
 
 	results, err := client.SearchDetectors(limit, name, offset, tags)
 	assert.NoError(t, err, "Unexpected error search detector")
@@ -143,7 +143,7 @@ func TestUpdateDetector(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/detector/string", verifyRequest(t, "PUT", http.StatusOK, nil, "detector/update_success.json"))
+	mux.HandleFunc("/v2/detector/string", verifyRequest(t, "PUT", true, http.StatusOK, nil, "detector/update_success.json"))
 
 	result, err := client.UpdateDetector("string", &detector.CreateUpdateDetectorRequest{
 		Name: "string",
@@ -156,7 +156,7 @@ func TestUpdateMissingDetector(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/detector/string", verifyRequest(t, "PUT", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/detector/string", verifyRequest(t, "PUT", true, http.StatusNotFound, nil, ""))
 
 	result, err := client.UpdateDetector("string", &detector.CreateUpdateDetectorRequest{
 		Name: "string",

--- a/gcp_integration_test.go
+++ b/gcp_integration_test.go
@@ -12,7 +12,7 @@ func TestCreateGCPIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration", verifyRequest(t, "POST", http.StatusOK, nil, "integration/create_gcp_success.json"))
+	mux.HandleFunc("/v2/integration", verifyRequest(t, "POST", true, http.StatusOK, nil, "integration/create_gcp_success.json"))
 
 	result, err := client.CreateGCPIntegration(&integration.GCPIntegration{
 		Type: "GCP",
@@ -25,7 +25,7 @@ func TestGetGCPIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "GET", http.StatusOK, nil, "integration/create_gcp_success.json"))
+	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "GET", true, http.StatusOK, nil, "integration/create_gcp_success.json"))
 
 	result, err := client.GetGCPIntegration("id")
 	assert.NoError(t, err, "Unexpected error getting integration")
@@ -36,7 +36,7 @@ func TestUpdateGCPIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "PUT", http.StatusOK, nil, "integration/create_gcp_success.json"))
+	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "PUT", true, http.StatusOK, nil, "integration/create_gcp_success.json"))
 
 	result, err := client.UpdateGCPIntegration("id", &integration.GCPIntegration{
 		Type: "GCP",
@@ -49,7 +49,7 @@ func TestDeleteGCPIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "DELETE", http.StatusNoContent, nil, ""))
+	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "DELETE", true, http.StatusNoContent, nil, ""))
 
 	err := client.DeleteGCPIntegration("id")
 	assert.NoError(t, err, "Unexpected error creating integration")

--- a/integration_test.go
+++ b/integration_test.go
@@ -11,7 +11,7 @@ func TestDeleteIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/string", verifyRequest(t, "DELETE", http.StatusNoContent, nil, ""))
+	mux.HandleFunc("/v2/integration/string", verifyRequest(t, "DELETE", true, http.StatusNoContent, nil, ""))
 
 	err := client.DeleteIntegration("string")
 	assert.NoError(t, err, "Unexpected error deleting integration")
@@ -21,7 +21,7 @@ func TestDeleteMissingIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/string", verifyRequest(t, "DELETE", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/integration/string", verifyRequest(t, "DELETE", true, http.StatusNotFound, nil, ""))
 
 	err := client.DeleteIntegration("string")
 	assert.Error(t, err, "Should get error error deleting missing integration")
@@ -31,7 +31,7 @@ func TestGetIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/string", verifyRequest(t, "GET", http.StatusOK, nil, "integration/get_success.json"))
+	mux.HandleFunc("/v2/integration/string", verifyRequest(t, "GET", true, http.StatusOK, nil, "integration/get_success.json"))
 
 	result, err := client.GetIntegration("string")
 	assert.NoError(t, err, "Unexpected error getting integration")
@@ -43,7 +43,7 @@ func TestGetMissingIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/string", verifyRequest(t, "GET", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/integration/string", verifyRequest(t, "GET", true, http.StatusNotFound, nil, ""))
 
 	result, err := client.GetIntegration("string")
 	assert.Error(t, err, "Should get an error getting missing integration")

--- a/jira_integration_test.go
+++ b/jira_integration_test.go
@@ -12,7 +12,7 @@ func TestCreateJiraIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration", verifyRequest(t, "POST", http.StatusOK, nil, "integration/create_jira_success.json"))
+	mux.HandleFunc("/v2/integration", verifyRequest(t, "POST", true, http.StatusOK, nil, "integration/create_jira_success.json"))
 
 	result, err := client.CreateJiraIntegration(&integration.JiraIntegration{
 		Type: "Jira",
@@ -25,7 +25,7 @@ func TestGetJiraIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "GET", http.StatusOK, nil, "integration/create_jira_success.json"))
+	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "GET", true, http.StatusOK, nil, "integration/create_jira_success.json"))
 
 	result, err := client.GetJiraIntegration("id")
 	assert.NoError(t, err, "Unexpected error getting integration")
@@ -36,7 +36,7 @@ func TestUpdateJiraIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "PUT", http.StatusOK, nil, "integration/create_jira_success.json"))
+	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "PUT", true, http.StatusOK, nil, "integration/create_jira_success.json"))
 
 	result, err := client.UpdateJiraIntegration("id", &integration.JiraIntegration{
 		Type: "Jira",
@@ -49,7 +49,7 @@ func TestDeleteJiraIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "DELETE", http.StatusNoContent, nil, ""))
+	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "DELETE", true, http.StatusNoContent, nil, ""))
 
 	err := client.DeleteJiraIntegration("id")
 	assert.NoError(t, err, "Unexpected error creating integration")

--- a/metrics_metadata_test.go
+++ b/metrics_metadata_test.go
@@ -15,7 +15,7 @@ func TestGetDimension(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/dimension/string/string2", verifyRequest(t, "GET", http.StatusOK, nil, "metrics_metadata/get_dimension_success.json"))
+	mux.HandleFunc("/v2/dimension/string/string2", verifyRequest(t, "GET", true, http.StatusOK, nil, "metrics_metadata/get_dimension_success.json"))
 
 	result, err := client.GetDimension("string", "string2")
 	assert.NoError(t, err, "Unexpected error getting dimension")
@@ -26,7 +26,7 @@ func TestGetMissingDimension(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/dimension/string/string2", verifyRequest(t, "GET", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/dimension/string/string2", verifyRequest(t, "GET", true, http.StatusNotFound, nil, ""))
 
 	result, err := client.GetDimension("string", "string2")
 	assert.Error(t, err, "Should have gotten an error from a missing dimension")
@@ -47,7 +47,7 @@ func TestSearchDimension(t *testing.T) {
 	params.Add("limit", strconv.Itoa(limit))
 	params.Add("offset", strconv.Itoa(offset))
 
-	mux.HandleFunc("/v2/dimension", verifyRequest(t, "GET", http.StatusOK, params, "metrics_metadata/dimension_search_success.json"))
+	mux.HandleFunc("/v2/dimension", verifyRequest(t, "GET", true, http.StatusOK, params, "metrics_metadata/dimension_search_success.json"))
 
 	results, err := client.SearchDimension(query, orderBy, limit, offset)
 	assert.NoError(t, err, "Unexpected error search dimensions")
@@ -58,7 +58,7 @@ func TestUpdateDimension(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/dimension/string/string", verifyRequest(t, "PUT", http.StatusOK, nil, "metrics_metadata/update_dimension_success.json"))
+	mux.HandleFunc("/v2/dimension/string/string", verifyRequest(t, "PUT", true, http.StatusOK, nil, "metrics_metadata/update_dimension_success.json"))
 
 	result, err := client.UpdateDimension("string", "string", &metrics_metadata.Dimension{
 		Key: "string",
@@ -71,7 +71,7 @@ func TestUpdateMissingDimension(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/dimension/string/string2", verifyRequest(t, "PUT", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/dimension/string/string2", verifyRequest(t, "PUT", true, http.StatusNotFound, nil, ""))
 
 	result, err := client.UpdateDimension("string", "string2", &metrics_metadata.Dimension{
 		Key: "string",
@@ -84,7 +84,7 @@ func TestGetMetric(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/metric/string", verifyRequest(t, "GET", http.StatusOK, nil, "metrics_metadata/get_metric_success.json"))
+	mux.HandleFunc("/v2/metric/string", verifyRequest(t, "GET", true, http.StatusOK, nil, "metrics_metadata/get_metric_success.json"))
 
 	result, err := client.GetMetric("string")
 	assert.NoError(t, err, "Unexpected error getting metric")
@@ -95,7 +95,7 @@ func TestGetMissingMetric(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/metric/string", verifyRequest(t, "GET", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/metric/string", verifyRequest(t, "GET", true, http.StatusNotFound, nil, ""))
 
 	result, err := client.GetMetric("string")
 	assert.Error(t, err, "Should have gotten an error from a missing metric")
@@ -116,7 +116,7 @@ func TestSearchMetric(t *testing.T) {
 	params.Add("limit", strconv.Itoa(limit))
 	params.Add("offset", strconv.Itoa(offset))
 
-	mux.HandleFunc("/v2/metric", verifyRequest(t, "GET", http.StatusOK, params, "metrics_metadata/metric_search_success.json"))
+	mux.HandleFunc("/v2/metric", verifyRequest(t, "GET", true, http.StatusOK, params, "metrics_metadata/metric_search_success.json"))
 
 	results, err := client.SearchMetric(query, orderBy, limit, offset)
 	assert.NoError(t, err, "Unexpected error search metrics")
@@ -127,7 +127,7 @@ func TestGetMetricTimeSeries(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/metrictimeseries/string", verifyRequest(t, "GET", http.StatusOK, nil, "metrics_metadata/get_metric_time_series_success.json"))
+	mux.HandleFunc("/v2/metrictimeseries/string", verifyRequest(t, "GET", true, http.StatusOK, nil, "metrics_metadata/get_metric_time_series_success.json"))
 
 	result, err := client.GetMetricTimeSeries("string")
 	assert.NoError(t, err, "Unexpected error getting metric time series")
@@ -138,7 +138,7 @@ func TestGetMissingMetricTimeSeries(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/metrictimeseries/string", verifyRequest(t, "GET", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/metrictimeseries/string", verifyRequest(t, "GET", true, http.StatusNotFound, nil, ""))
 
 	result, err := client.GetMetricTimeSeries("string")
 	assert.Error(t, err, "Should have gotten an error from a missing metric time series")
@@ -159,7 +159,7 @@ func TestSearchMetricTimeSeries(t *testing.T) {
 	params.Add("limit", strconv.Itoa(limit))
 	params.Add("offset", strconv.Itoa(offset))
 
-	mux.HandleFunc("/v2/metrictimeseries", verifyRequest(t, "GET", http.StatusOK, params, "metrics_metadata/metric_time_series_search_success.json"))
+	mux.HandleFunc("/v2/metrictimeseries", verifyRequest(t, "GET", true, http.StatusOK, params, "metrics_metadata/metric_time_series_search_success.json"))
 
 	results, err := client.SearchMetricTimeSeries(query, orderBy, limit, offset)
 	assert.NoError(t, err, "Unexpected error search metric time series")
@@ -180,7 +180,7 @@ func TestSearchTag(t *testing.T) {
 	params.Add("limit", strconv.Itoa(limit))
 	params.Add("offset", strconv.Itoa(offset))
 
-	mux.HandleFunc("/v2/tag", verifyRequest(t, "GET", http.StatusOK, params, "metrics_metadata/tag_search_success.json"))
+	mux.HandleFunc("/v2/tag", verifyRequest(t, "GET", true, http.StatusOK, params, "metrics_metadata/tag_search_success.json"))
 
 	results, err := client.SearchTag(query, orderBy, limit, offset)
 	assert.NoError(t, err, "Unexpected error search tags")
@@ -191,7 +191,7 @@ func TestGetTag(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/tag/string", verifyRequest(t, "GET", http.StatusOK, nil, "metrics_metadata/get_tag_success.json"))
+	mux.HandleFunc("/v2/tag/string", verifyRequest(t, "GET", true, http.StatusOK, nil, "metrics_metadata/get_tag_success.json"))
 
 	result, err := client.GetTag("string")
 	assert.NoError(t, err, "Unexpected error getting Tag")
@@ -202,7 +202,7 @@ func TestGetMissingTag(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/tag/string", verifyRequest(t, "GET", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/tag/string", verifyRequest(t, "GET", true, http.StatusNotFound, nil, ""))
 
 	result, err := client.GetTag("string")
 	assert.Error(t, err, "Should have gotten an error from a missing tag")
@@ -213,7 +213,7 @@ func TestDeleteTag(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/tag/string", verifyRequest(t, "DELETE", http.StatusNoContent, nil, ""))
+	mux.HandleFunc("/v2/tag/string", verifyRequest(t, "DELETE", true, http.StatusNoContent, nil, ""))
 
 	err := client.DeleteTag("string")
 	assert.NoError(t, err, "Unexpected error deleting tag")
@@ -223,7 +223,7 @@ func TestDeleteMissingTag(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/tag", verifyRequest(t, "POST", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/tag", verifyRequest(t, "POST", true, http.StatusNotFound, nil, ""))
 
 	err := client.DeleteTag("example")
 	assert.Error(t, err, "Should have gotten an error from a missing delete")
@@ -233,7 +233,7 @@ func TestUpdateCreateTag(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/tag/string", verifyRequest(t, "PUT", http.StatusOK, nil, "metrics_metadata/create_update_tag_success.json"))
+	mux.HandleFunc("/v2/tag/string", verifyRequest(t, "PUT", true, http.StatusOK, nil, "metrics_metadata/create_update_tag_success.json"))
 
 	result, err := client.CreateUpdateTag("string", &metrics_metadata.CreateUpdateTagRequest{
 		Description: "string",

--- a/opsgenie_integration_test.go
+++ b/opsgenie_integration_test.go
@@ -12,7 +12,7 @@ func TestCreateOpsgenieIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration", verifyRequest(t, "POST", http.StatusOK, nil, "integration/create_opsgenie_success.json"))
+	mux.HandleFunc("/v2/integration", verifyRequest(t, "POST", true, http.StatusOK, nil, "integration/create_opsgenie_success.json"))
 
 	result, err := client.CreateOpsgenieIntegration(&integration.OpsgenieIntegration{
 		Type: "Opsgenie",
@@ -25,7 +25,7 @@ func TestGetOpsgenieIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "GET", http.StatusOK, nil, "integration/create_opsgenie_success.json"))
+	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "GET", true, http.StatusOK, nil, "integration/create_opsgenie_success.json"))
 
 	result, err := client.GetOpsgenieIntegration("id")
 	assert.NoError(t, err, "Unexpected error getting integration")
@@ -36,7 +36,7 @@ func TestUpdateOpsgenieIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "PUT", http.StatusOK, nil, "integration/create_opsgenie_success.json"))
+	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "PUT", true, http.StatusOK, nil, "integration/create_opsgenie_success.json"))
 
 	result, err := client.UpdateOpsgenieIntegration("id", &integration.OpsgenieIntegration{
 		Type: "Opsgenie",
@@ -49,7 +49,7 @@ func TestDeleteOpsgenieIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "DELETE", http.StatusNoContent, nil, ""))
+	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "DELETE", true, http.StatusNoContent, nil, ""))
 
 	err := client.DeleteOpsgenieIntegration("id")
 	assert.NoError(t, err, "Unexpected error creating integration")

--- a/organization_test.go
+++ b/organization_test.go
@@ -15,7 +15,7 @@ func TestGetOrganization(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/organization/string", verifyRequest(t, "GET", http.StatusOK, nil, "organization/get_success.json"))
+	mux.HandleFunc("/v2/organization/string", verifyRequest(t, "GET", true, http.StatusOK, nil, "organization/get_success.json"))
 
 	result, err := client.GetOrganization("string")
 	assert.NoError(t, err, "Unexpected error getting organization")
@@ -26,7 +26,7 @@ func TestGetMissingOrganization(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/organization/string", verifyRequest(t, "GET", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/organization/string", verifyRequest(t, "GET", true, http.StatusNotFound, nil, ""))
 
 	result, err := client.GetDetector("string")
 	assert.Error(t, err, "Should have gotten an error from a missing organization")
@@ -37,7 +37,7 @@ func TestGetMember(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/organization/member/string", verifyRequest(t, "GET", http.StatusOK, nil, "organization/get_member_success.json"))
+	mux.HandleFunc("/v2/organization/member/string", verifyRequest(t, "GET", true, http.StatusOK, nil, "organization/get_member_success.json"))
 
 	result, err := client.GetMember("string")
 	assert.NoError(t, err, "Unexpected error getting member")
@@ -48,7 +48,7 @@ func TestGetMissingMember(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/organization/member/string", verifyRequest(t, "GET", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/organization/member/string", verifyRequest(t, "GET", true, http.StatusNotFound, nil, ""))
 
 	result, err := client.GetMember("string")
 	assert.Error(t, err, "Should have gotten an error from a missing member")
@@ -59,7 +59,7 @@ func TestInviteMember(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/organization/member", verifyRequest(t, "POST", http.StatusOK, nil, "organization/invite_member_success.json"))
+	mux.HandleFunc("/v2/organization/member", verifyRequest(t, "POST", true, http.StatusOK, nil, "organization/invite_member_success.json"))
 
 	results, err := client.InviteMember(&organization.CreateUpdateMemberRequest{
 		Email: "string",
@@ -72,7 +72,7 @@ func TestGetInviteMembers(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/organization/members", verifyRequest(t, "POST", http.StatusOK, nil, "organization/invite_members_success.json"))
+	mux.HandleFunc("/v2/organization/members", verifyRequest(t, "POST", true, http.StatusOK, nil, "organization/invite_members_success.json"))
 
 	members := make([]*organization.Member, 1)
 	members[0] = &organization.Member{
@@ -99,7 +99,7 @@ func TestGetOrganizationMembers(t *testing.T) {
 	params.Add("offset", strconv.Itoa(offset))
 	params.Add("orderBy", orderBy)
 
-	mux.HandleFunc("/v2/organization/member", verifyRequest(t, "GET", http.StatusOK, params, "organization/get_organization_members_success.json"))
+	mux.HandleFunc("/v2/organization/member", verifyRequest(t, "GET", true, http.StatusOK, params, "organization/get_organization_members_success.json"))
 
 	results, err := client.GetOrganizationMembers(limit, query, offset, orderBy)
 	assert.NoError(t, err, "Unexpected error getting members")
@@ -110,7 +110,7 @@ func TestDeleteMember(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/organization/member/string", verifyRequest(t, "DELETE", http.StatusNoContent, nil, ""))
+	mux.HandleFunc("/v2/organization/member/string", verifyRequest(t, "DELETE", true, http.StatusNoContent, nil, ""))
 
 	err := client.DeleteMember("string")
 	assert.NoError(t, err, "Unexpected error deleting member")
@@ -120,7 +120,7 @@ func TestDeleteMissingMember(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/organization/member", verifyRequest(t, "POST", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/organization/member", verifyRequest(t, "POST", true, http.StatusNotFound, nil, ""))
 
 	err := client.DeleteMember("example")
 	assert.Error(t, err, "Should have gotten an error from a missing delete")

--- a/orgtoken_test.go
+++ b/orgtoken_test.go
@@ -14,7 +14,7 @@ func TestCreateOrgToken(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/token", verifyRequest(t, "POST", http.StatusOK, nil, "orgtoken/create_success.json"))
+	mux.HandleFunc("/v2/token", verifyRequest(t, "POST", true, http.StatusOK, nil, "orgtoken/create_success.json"))
 
 	quota := int32(1234)
 	quotaThreshold := int32(1235)
@@ -33,7 +33,7 @@ func TestCreateBadOrgToken(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/token", verifyRequest(t, "POST", http.StatusBadRequest, nil, ""))
+	mux.HandleFunc("/v2/token", verifyRequest(t, "POST", true, http.StatusBadRequest, nil, ""))
 
 	result, err := client.CreateOrgToken(&orgtoken.CreateUpdateTokenRequest{
 		Name: "string",
@@ -46,7 +46,7 @@ func TestDeleteOrgToken(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/token/string%2Ffart", verifyRequest(t, "DELETE", http.StatusNoContent, nil, ""))
+	mux.HandleFunc("/v2/token/string%2Ffart", verifyRequest(t, "DELETE", true, http.StatusNoContent, nil, ""))
 
 	err := client.DeleteOrgToken("string/fart")
 	assert.NoError(t, err, "Unexpected error deleting token")
@@ -56,7 +56,7 @@ func TestDeleteMissingOrgToken(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/token", verifyRequest(t, "POST", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/token", verifyRequest(t, "POST", true, http.StatusNotFound, nil, ""))
 
 	err := client.DeleteOrgToken("example")
 	assert.Error(t, err, "Should have gotten an error from a missing delete")
@@ -66,7 +66,7 @@ func TestGetOrgToken(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/token/string%2Ffart", verifyRequest(t, "GET", http.StatusOK, nil, "orgtoken/get_success.json"))
+	mux.HandleFunc("/v2/token/string%2Ffart", verifyRequest(t, "GET", true, http.StatusOK, nil, "orgtoken/get_success.json"))
 
 	result, err := client.GetOrgToken("string/fart")
 	assert.NoError(t, err, "Unexpected error getting token")
@@ -77,7 +77,7 @@ func TestGetMissingOrgToken(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/token/string%2Ffart", verifyRequest(t, "GET", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/token/string%2Ffart", verifyRequest(t, "GET", true, http.StatusNotFound, nil, ""))
 
 	result, err := client.GetOrgToken("string/fart")
 	assert.Error(t, err, "Should have gotten an error from a missing token")
@@ -96,7 +96,7 @@ func TestSearchOrgToken(t *testing.T) {
 	params.Add("name", url.PathEscape(name))
 	params.Add("offset", strconv.Itoa(offset))
 
-	mux.HandleFunc("/v2/token", verifyRequest(t, "GET", http.StatusOK, params, "orgtoken/search_success.json"))
+	mux.HandleFunc("/v2/token", verifyRequest(t, "GET", true, http.StatusOK, params, "orgtoken/search_success.json"))
 
 	results, err := client.SearchOrgTokens(limit, name, offset)
 	assert.NoError(t, err, "Unexpected error search token")
@@ -107,7 +107,7 @@ func TestUpdateOrgToken(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/token/string%2Ffart", verifyRequest(t, "PUT", http.StatusOK, nil, "orgtoken/update_success.json"))
+	mux.HandleFunc("/v2/token/string%2Ffart", verifyRequest(t, "PUT", true, http.StatusOK, nil, "orgtoken/update_success.json"))
 
 	result, err := client.UpdateOrgToken("string/fart", &orgtoken.CreateUpdateTokenRequest{
 		Name: "string",
@@ -120,7 +120,7 @@ func TestUpdateMissingOrgToken(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/token/string", verifyRequest(t, "PUT", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/token/string", verifyRequest(t, "PUT", true, http.StatusNotFound, nil, ""))
 
 	result, err := client.UpdateOrgToken("string", &orgtoken.CreateUpdateTokenRequest{
 		Name: "string",

--- a/pagerduty_integration_test.go
+++ b/pagerduty_integration_test.go
@@ -12,7 +12,7 @@ func TestCreatePagerDutyIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration", verifyRequest(t, "POST", http.StatusOK, nil, "integration/create_pd_success.json"))
+	mux.HandleFunc("/v2/integration", verifyRequest(t, "POST", true, http.StatusOK, nil, "integration/create_pd_success.json"))
 
 	result, err := client.CreatePagerDutyIntegration(&integration.PagerDutyIntegration{
 		Type: "PagerDuty",
@@ -25,7 +25,7 @@ func TestGetPagerDutyIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "GET", http.StatusOK, nil, "integration/create_pd_success.json"))
+	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "GET", true, http.StatusOK, nil, "integration/create_pd_success.json"))
 
 	result, err := client.GetPagerDutyIntegration("id")
 	assert.NoError(t, err, "Unexpected error getting integration")
@@ -36,7 +36,7 @@ func TestUpdatePagerDutyIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "PUT", http.StatusOK, nil, "integration/create_pd_success.json"))
+	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "PUT", true, http.StatusOK, nil, "integration/create_pd_success.json"))
 
 	result, err := client.UpdatePagerDutyIntegration("id", &integration.PagerDutyIntegration{
 		Type: "PagerDuty",
@@ -49,7 +49,7 @@ func TestDeletePagerDutyIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "DELETE", http.StatusNoContent, nil, ""))
+	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "DELETE", true, http.StatusNoContent, nil, ""))
 
 	err := client.DeletePagerDutyIntegration("id")
 	assert.NoError(t, err, "Unexpected error creating integration")

--- a/sessiontoken.go
+++ b/sessiontoken.go
@@ -20,7 +20,9 @@ func (c *Client) CreateSessionToken(tokenRequest *sessiontoken.CreateTokenReques
 		return nil, err
 	}
 
-	resp, err := c.doRequest("POST", SessionTokenAPIURL, nil, bytes.NewReader(payload))
+	// we need to explicitly pass an empty token (which means it wont get set in the header)
+	// the API accepts either no token or a valid token, but not an empty token.
+	resp, err := c.doRequestWithToken("POST", SessionTokenAPIURL, nil, bytes.NewReader(payload), "")
 	if err != nil {
 		return nil, err
 	}

--- a/sessiontoken.go
+++ b/sessiontoken.go
@@ -1,0 +1,55 @@
+package signalfx
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/signalfx/signalfx-go/sessiontoken"
+)
+
+// SessionTokenAPIURL is the base URL for interacting with org tokens.
+const SessionTokenAPIURL = "/v2/session"
+
+// CreateOrgToken creates a org token.
+func (c *Client) CreateSessionToken(tokenRequest *sessiontoken.CreateTokenRequest) (*sessiontoken.Token, error) {
+	payload, err := json.Marshal(tokenRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.doRequest("POST", SessionTokenAPIURL, nil, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		message, _ := ioutil.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Bad status %d: %s", resp.StatusCode, message)
+	}
+
+	sessionToken := &sessiontoken.Token{}
+
+	err = json.NewDecoder(resp.Body).Decode(sessionToken)
+
+	return sessionToken, err
+}
+
+// DeleteOrgToken deletes a token.
+func (c *Client) DeleteSessionToken(token string) error {
+	resp, err := c.doRequestWithToken("DELETE", SessionTokenAPIURL, nil, nil, token)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		message, _ := ioutil.ReadAll(resp.Body)
+		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
+	}
+
+	return nil
+}

--- a/sessiontoken/model_create_token_request.go
+++ b/sessiontoken/model_create_token_request.go
@@ -1,0 +1,9 @@
+package sessiontoken
+
+// Properties of a session token request.
+type CreateTokenRequest struct {
+	// The email address you used to join the organization for which you want a session token. Only used for Create Token requests
+	Email string `json:"email"`
+	// The password you provided to SignalFx when you accepted an invitation to join an organization. Only used for Create Token requests
+	Password string `json:"password"`
+}

--- a/sessiontoken/model_token.go
+++ b/sessiontoken/model_token.go
@@ -1,0 +1,33 @@
+package sessiontoken
+
+// Properties of a session token, in the form of a JSON object
+type Token struct {
+	// The user session token used for API requests
+	AccessToken    string      `json:"accessToken"`
+	// unknown (not documented)
+	AuthMethod     string      `json:"authMethod"`
+	// The internal user ID of the user who created the token
+	CreatedBy      string	   `json:"createdBy"`
+	// The date and time that the token was created, in Unix time This property is set by the system, and you can't change it.
+	CreatedMs      int64         `json:"createdMs"`
+	// Indicates if the token is disabled or not. When you first create a token, the value of disabled is false.
+	Disabled       bool        `json:"disabled"`
+	// The email address submitted in the request to create the token
+	Email          string      `json:"email"`
+	// The date and time that the token will expire, in Unix time
+	ExpiryMs       int64       `json:"expiryMs"`
+	// The SignalFx identifier of this access token
+	ID             string      `json:"id"`
+	// The SignalFx identifier of the organization that the user belongs to
+	OrganizationID string      `json:"organizationId"`
+	// unknown (not documented)
+	PersonaID      string      `json:"personaId"`
+	// unknown (not documented)
+	ReadOnly       bool        `json:"readOnly"`
+	// Always set to ORG_USER
+	SessionType    string      `json:"sessionType"`
+	// The date and time that the token was updated, in Unix time For a successful "create token" request, this value is the same as that for createdMs. This value is set by the system, and you can't change it.
+	UpdatedMs      int         `json:"updatedMs"`
+	// The SignalFx identifier of the user who created the token
+	UserID         string      `json:"userId"`
+}

--- a/sessiontoken_test.go
+++ b/sessiontoken_test.go
@@ -1,0 +1,59 @@
+package signalfx
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/signalfx/signalfx-go/sessiontoken"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateSessionToken(t *testing.T) {
+	teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/session", verifyRequest(t, "POST", http.StatusOK, nil, "sessiontoken/create_success.json"))
+
+	result, err := client.CreateSessionToken(&sessiontoken.CreateTokenRequest{
+		Email: "testemail@test.com",
+		Password: "testpassword",
+	})
+	assert.NoError(t, err, "Unexpected error creating orgtoken")
+	assert.Equal(t, "testemail@test.com", result.Email, "Email does not match")
+	assert.Equal(t, "mytokenvalue", result.AccessToken, "Access token does not match")
+}
+
+func TestCreateBadSessionToken(t *testing.T) {
+	teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/session", verifyRequest(t, "POST", http.StatusBadRequest, nil, ""))
+
+	result, err := client.CreateSessionToken(&sessiontoken.CreateTokenRequest{
+		Email: "email",
+	})
+	assert.Error(t, err, "Should have gotten an error from a bad create")
+	assert.Nil(t, result, "Should have a null token on bad create")
+}
+
+func TestDeleteSessionToken(t *testing.T) {
+	teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/session", verifyRequest(t, "DELETE", http.StatusNoContent, nil, ""))
+
+	err := client.DeleteSessionToken(TestToken)
+	assert.NoError(t, err, "Unexpected error deleting token")
+}
+
+func TestDeleteMissingSessionToken(t *testing.T) {
+	teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/session", verifyRequest(t, "DELETE", http.StatusNotFound, nil, ""))
+
+	err := client.DeleteSessionToken(TestToken)
+	assert.Error(t, err, "Should have gotten an error from a missing delete")
+}
+

--- a/slack_integration_test.go
+++ b/slack_integration_test.go
@@ -12,7 +12,7 @@ func TestCreateSlackIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration", verifyRequest(t, "POST", http.StatusOK, nil, "integration/create_slack_success.json"))
+	mux.HandleFunc("/v2/integration", verifyRequest(t, "POST", true, http.StatusOK, nil, "integration/create_slack_success.json"))
 
 	result, err := client.CreateSlackIntegration(&integration.SlackIntegration{
 		Type: "Slack",
@@ -25,7 +25,7 @@ func TestGetSlackIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "GET", http.StatusOK, nil, "integration/create_slack_success.json"))
+	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "GET", true, http.StatusOK, nil, "integration/create_slack_success.json"))
 
 	result, err := client.GetSlackIntegration("id")
 	assert.NoError(t, err, "Unexpected error getting integration")
@@ -36,7 +36,7 @@ func TestUpdateSlackIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "PUT", http.StatusOK, nil, "integration/create_slack_success.json"))
+	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "PUT", true, http.StatusOK, nil, "integration/create_slack_success.json"))
 
 	result, err := client.UpdateSlackIntegration("id", &integration.SlackIntegration{
 		Type: "Slack",
@@ -49,7 +49,7 @@ func TestDeleteSlackIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "DELETE", http.StatusNoContent, nil, ""))
+	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "DELETE", true, http.StatusNoContent, nil, ""))
 
 	err := client.DeleteSlackIntegration("id")
 	assert.NoError(t, err, "Unexpected error creating integration")

--- a/team_test.go
+++ b/team_test.go
@@ -14,7 +14,7 @@ func TestCreateTeam(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/team", verifyRequest(t, "POST", http.StatusOK, nil, "team/create_success.json"))
+	mux.HandleFunc("/v2/team", verifyRequest(t, "POST", true, http.StatusOK, nil, "team/create_success.json"))
 
 	result, err := client.CreateTeam(&team.CreateUpdateTeamRequest{
 		Name: "string",
@@ -27,7 +27,7 @@ func TestCreateBadTeam(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/team", verifyRequest(t, "POST", http.StatusBadRequest, nil, ""))
+	mux.HandleFunc("/v2/team", verifyRequest(t, "POST", true, http.StatusBadRequest, nil, ""))
 
 	result, err := client.CreateTeam(&team.CreateUpdateTeamRequest{
 		Name: "string",
@@ -40,7 +40,7 @@ func TestDeleteTeam(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/team/string", verifyRequest(t, "DELETE", http.StatusNoContent, nil, ""))
+	mux.HandleFunc("/v2/team/string", verifyRequest(t, "DELETE", true, http.StatusNoContent, nil, ""))
 
 	err := client.DeleteTeam("string")
 	assert.NoError(t, err, "Unexpected error getting Team")
@@ -50,7 +50,7 @@ func TestDeleteMissingTeam(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/team/string", verifyRequest(t, "DELETE", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/team/string", verifyRequest(t, "DELETE", true, http.StatusNotFound, nil, ""))
 
 	err := client.DeleteTeam("string")
 	assert.Error(t, err, "Should have gotten an error code for a missing team")
@@ -60,7 +60,7 @@ func TestGetTeam(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/team/string", verifyRequest(t, "GET", http.StatusOK, nil, "team/get_success.json"))
+	mux.HandleFunc("/v2/team/string", verifyRequest(t, "GET", true, http.StatusOK, nil, "team/get_success.json"))
 
 	result, err := client.GetTeam("string")
 	assert.NoError(t, err, "Unexpected error getting Team")
@@ -71,7 +71,7 @@ func TestGetMissingTeam(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/team/string", verifyRequest(t, "GET", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/team/string", verifyRequest(t, "GET", true, http.StatusNotFound, nil, ""))
 
 	result, err := client.GetTeam("string")
 	assert.Error(t, err, "Expected error getting missing team")
@@ -92,7 +92,7 @@ func TestSearchTeam(t *testing.T) {
 	params.Add("offset", strconv.Itoa(offset))
 	params.Add("tags", tags)
 
-	mux.HandleFunc("/v2/team", verifyRequest(t, "GET", http.StatusOK, params, "team/search_success.json"))
+	mux.HandleFunc("/v2/team", verifyRequest(t, "GET", true, http.StatusOK, params, "team/search_success.json"))
 
 	results, err := client.SearchTeam(limit, name, offset, tags)
 	assert.NoError(t, err, "Unexpected error search Team")
@@ -103,7 +103,7 @@ func TestUpdateTeam(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/team/string", verifyRequest(t, "PUT", http.StatusOK, nil, "team/update_success.json"))
+	mux.HandleFunc("/v2/team/string", verifyRequest(t, "PUT", true, http.StatusOK, nil, "team/update_success.json"))
 
 	result, err := client.UpdateTeam("string", &team.CreateUpdateTeamRequest{
 		Name: "string",
@@ -116,7 +116,7 @@ func TestUpdateMissingTeam(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/team/string", verifyRequest(t, "PUT", http.StatusNotFound, nil, ""))
+	mux.HandleFunc("/v2/team/string", verifyRequest(t, "PUT", true, http.StatusNotFound, nil, ""))
 
 	result, err := client.UpdateTeam("string", &team.CreateUpdateTeamRequest{
 		Name: "string",

--- a/testdata/fixtures/sessiontoken/create_success.json
+++ b/testdata/fixtures/sessiontoken/create_success.json
@@ -1,0 +1,18 @@
+{
+  "accessToken": "mytokenvalue",
+  "authMethod": "UNDEFINED",
+  "createdBy": null,
+  "createdMs": 0,
+  "disabled": false,
+  "email": "testemail@test.com",
+  "expiryMs": 1578715941041,
+  "id": "test_id",
+  "organizationId": "test_orgid",
+  "personaId": "test_personaid",
+  "readOnly": false,
+  "sessionType": "ORG_USER",
+  "updatedBy": null,
+  "updatedMs": 0,
+  "userId": "test_userid",
+  "userName": null
+}

--- a/victor_ops_integration_test.go
+++ b/victor_ops_integration_test.go
@@ -12,7 +12,7 @@ func TestCreateVictorOpsIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration", verifyRequest(t, "POST", http.StatusOK, nil, "integration/create_victor_ops_success.json"))
+	mux.HandleFunc("/v2/integration", verifyRequest(t, "POST", true, http.StatusOK, nil, "integration/create_victor_ops_success.json"))
 
 	result, err := client.CreateVictorOpsIntegration(&integration.VictorOpsIntegration{
 		Type: "VictorOps",
@@ -25,7 +25,7 @@ func TestGetVictorOpsIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "GET", http.StatusOK, nil, "integration/create_victor_ops_success.json"))
+	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "GET", true, http.StatusOK, nil, "integration/create_victor_ops_success.json"))
 
 	result, err := client.GetVictorOpsIntegration("id")
 	assert.NoError(t, err, "Unexpected error getting integration")
@@ -36,7 +36,7 @@ func TestUpdateVictorOpsIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "PUT", http.StatusOK, nil, "integration/create_victor_ops_success.json"))
+	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "PUT", true, http.StatusOK, nil, "integration/create_victor_ops_success.json"))
 
 	result, err := client.UpdateVictorOpsIntegration("id", &integration.VictorOpsIntegration{
 		Type: "VictorOps",
@@ -49,7 +49,7 @@ func TestDeleteVictorOpsIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "DELETE", http.StatusNoContent, nil, ""))
+	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "DELETE", true, http.StatusNoContent, nil, ""))
 
 	err := client.DeleteVictorOpsIntegration("id")
 	assert.NoError(t, err, "Unexpected error creating integration")


### PR DESCRIPTION
Allows users of the library to create / delete session tokens, as per https://developers.signalfx.com/sessiontokens_reference.html