### PR TITLE
Add sfxAwsAccountArn field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.6.12, Pending
+# 1.6.13, Pending
 
 ## Added
 
@@ -7,6 +7,12 @@
 ## Bugfixes
 
 ## Removed
+
+# 1.6.12, 2020-01-21
+
+## Added
+
+* Field `sfxAwsAccountArn` added to AWS response
 
 # 1.6.11, 2019-12-18
 

--- a/integration/model_aws_cloud_watch_integration.go
+++ b/integration/model_aws_cloud_watch_integration.go
@@ -48,6 +48,8 @@ type AwsCloudWatchIntegration struct {
 	RoleArn string `json:"roleArn,omitempty"`
 	// Array of AWS services that you want SignalFx to monitor. Each element is a string designating an AWS service
 	Services []AwsService `json:"services,omitempty"`
+	// The account ARN used with this AWS integration.
+	SfxAwsAccountArn string `json:"sfxAwsAccountArn,omitempty"`
 	// If you specify `\"authMethod\": \"SecurityToken\"` in your request to create an AWS integration object, use this property to specify the token.
 	Token string `json:"token,omitempty"`
 	// Flag that controls how SignalFx checks for large amounts of data for this AWS integration. If `true`, SignalFx checks to see if the integration is returning a large amount of data.

--- a/testdata/fixtures/integration/create_aws_success.json
+++ b/testdata/fixtures/integration/create_aws_success.json
@@ -43,5 +43,6 @@
   "services": [
     "AWS/ApiGateway"
   ],
+  "sfxAwsAccountArn": "arn:aws:iam::1234567890:root",
   "token": "string"
 }


### PR DESCRIPTION
# Summar

Add `sfxAwsAccountArn` field.

# Motivation

This field was added to improve Terraform's use of the the AWS/integration API.