### PR TITLE
Align int64 counters in writer to 64-bit boundaries

### DIFF
--- a/writer/datapoint_writer.gen.go
+++ b/writer/datapoint_writer.gen.go
@@ -78,6 +78,8 @@ type DatapointWriter struct {
 	// risking overwriting in the middle of sending.
 	chunkSliceCache chan []*datapoint.Datapoint
 
+	_ int32
+
 	requestsActive int64
 	// Datapoints waiting to be sent but are blocked due to MaxRequests limit
 	totalWaiting int64

--- a/writer/span_writer.gen.go
+++ b/writer/span_writer.gen.go
@@ -79,6 +79,8 @@ type SpanWriter struct {
 	// risking overwriting in the middle of sending.
 	chunkSliceCache chan []*trace.Span
 
+	_ int32
+
 	requestsActive int64
 	// Spans waiting to be sent but are blocked due to MaxRequests limit
 	totalWaiting int64

--- a/writer/template/writer.go
+++ b/writer/template/writer.go
@@ -75,6 +75,8 @@ type InstanceWriter struct {
 	// risking overwriting in the middle of sending.
 	chunkSliceCache chan []*Instance
 
+	_ int32
+
 	requestsActive int64
 	// Instances waiting to be sent but are blocked due to MaxRequests limit
 	totalWaiting int64


### PR DESCRIPTION
This manual alignment is required by the atomic package for methods like
atomic.AddInt64 to work properly on 32-bit systems.