### PR TITLE
implement ComputationError struct, so applications can index into error metadata

### DIFF
--- a/signalflow/computation.go
+++ b/signalflow/computation.go
@@ -42,17 +42,17 @@ type Computation struct {
 
 // ComputationError exposes the underlying metadata of a computation error
 type ComputationError struct {
-	Code      interface{}
-	Message   interface{}
-	ErrorType interface{}
+	Code      int
+	Message   string
+	ErrorType string
 }
 
 func (e *ComputationError) Error() string {
 	err := fmt.Sprintf("%v", e.Code)
-	if e.ErrorType != nil {
+	if e.ErrorType != "" {
 		err = fmt.Sprintf("%v (%v)", e.Code, e.ErrorType)
 	}
-	if e.Message != nil {
+	if e.Message != "" {
 		err = fmt.Sprintf("%v: %v", err, e.Message)
 	}
 	return err
@@ -202,10 +202,15 @@ func (c *Computation) processMessage(m messages.Message) {
 		}
 	case *messages.ErrorMessage:
 		rawData := v.RawData()
-		computationError := ComputationError{
-			Code:      rawData["error"],
-			Message:   rawData["message"],
-			ErrorType: rawData["errorType"],
+		computationError := ComputationError{}
+		if code, ok := rawData["error"]; ok {
+			computationError.Code = int(code.(float64))
+		}
+		if msg, ok := rawData["message"]; ok {
+			computationError.Message = msg.(string)
+		}
+		if errType, ok := rawData["errorType"]; ok {
+			computationError.ErrorType = errType.(string)
 		}
 		c.lastError = &computationError
 		c.cancel()

--- a/signalflow/computation_test.go
+++ b/signalflow/computation_test.go
@@ -2,7 +2,6 @@ package signalflow
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -28,8 +27,7 @@ func waitForDataMsg(t *testing.T, comp *Computation) (messages.Message, error) {
 				return nil, err
 			}
 
-			t.Fatal("unepxeted empty error")
-			return nil, fmt.Errorf("data message didn't get buffered")
+			t.Fatal("data message didn't get buffered")
 		}
 	}
 }

--- a/signalflow/computation_test.go
+++ b/signalflow/computation_test.go
@@ -210,7 +210,7 @@ func TestComputationError(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected computation error")
 	}
-	require.Equal(t, float64(400), err.(*ComputationError).Code)
+	require.Equal(t, 400, err.(*ComputationError).Code)
 	require.Equal(t, "ANALYTICS_PROGRAM_NAME_ERROR", err.(*ComputationError).ErrorType)
 	require.Equal(t, "We hit some error", err.(*ComputationError).Message)
 }


### PR DESCRIPTION
Based on the signalfx-python implementation[0][1], which always exposes a code and sometimes exposes a message/error type (if they are available).

[0] https://github.com/signalfx/signalfx-python/blob/cfbda55989bc0e7ff48be82f2510f378d97d30c6/signalfx/signalflow/ws.py#L311-L314
[1] https://github.com/signalfx/signalfx-python/blob/cfbda55989bc0e7ff48be82f2510f378d97d30c6/signalfx/signalflow/errors.py#L28-L35