### PR TITLE
make SearchDetectors "tags" optional

### DIFF
--- a/detector.go
+++ b/detector.go
@@ -152,7 +152,9 @@ func (c *Client) SearchDetectors(limit int, name string, offset int, tags string
 	params.Add("limit", strconv.Itoa(limit))
 	params.Add("name", name)
 	params.Add("offset", strconv.Itoa(offset))
-	params.Add("tags", tags)
+	if tags != "" {
+		params.Add("tags", tags)
+	}
 
 	resp, err := c.doRequest("GET", DetectorAPIURL, params, nil)
 


### PR DESCRIPTION
For endpoint `/v2/detector`, `name` is ignored if it is blank:

> If the string is empty, it's ignored and the API uses the other criteria in the query.

But the same is not true for `tags`, which will return an empty list. To work around this, we ignore the value of `tags` if it is empty.