### PR TITLE
Make "tags" and "name" optional for SearchCharts

### DIFF
--- a/chart.go
+++ b/chart.go
@@ -107,9 +107,13 @@ func (c *Client) UpdateChart(id string, chartRequest *chart.CreateUpdateChartReq
 func (c *Client) SearchCharts(limit int, name string, offset int, tags string) (*chart.SearchResult, error) {
 	params := url.Values{}
 	params.Add("limit", strconv.Itoa(limit))
-	params.Add("name", name)
+	if name != "" {
+		params.Add("name", name)
+	}
 	params.Add("offset", strconv.Itoa(offset))
-	params.Add("tags", tags)
+	if tags != "" {
+		params.Add("tags", tags)
+	}
 
 	resp, err := c.doRequest("GET", ChartAPIURL, params, nil)
 


### PR DESCRIPTION
Like https://github.com/signalfx/signalfx-go/pull/77, but for the `/chart` endpoint. 

`name` and `tags` are both optional values that are ignored if empty. This pull request updates `SearchCharts` to drop both parameters if empty, to return the documented results instead of an empty list.