### PR TITLE
Adjust close to check for non-nil and be before returns on errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,11 @@ workflows:
   build:
     jobs:
       - test:
-          name: "Go 1.11"
-          go_version: "1.11"
-      - test:
           name: "Go 1.12"
           go_version: "1.12"
       - test:
           name: "Go 1.13"
           go_version: "1.13"
+      - test:
+          name: "Go 1.14"
+          go_version: "1.14"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # 1.6.33, 2020-04-29
 
-* Adjust behavior to more reliably close HTTP bodies with sketchy replies.
+* Adjust behavior to more reliably close HTTP bodies with sketchy replies. [#81](https://github.com/signalfx/signalfx-go/pull/81)
 
 # 1.6.32, 2020-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # 1.6.33, 2020-04-29
 
-* Adjust behavior to more reliably close HTTP bodies with sketchy replies. [#81](https://github.com/signalfx/signalfx-go/pull/81)
+* Adjust behavior to more reliably close/fully-read HTTP bodies with sketchy replies. [#81](https://github.com/signalfx/signalfx-go/pull/81)
 
 # 1.6.32, 2020-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
-# 1.6.32, Pending
+# 1.6.34, Pending
+
+# 1.6.33, 2020-04-29
+
+* Adjust behavior to more reliably close HTTP bodies with sketchy replies.
+
+# 1.6.32, 2020-04-13
+
+## Improvements
+
+* Added User-Agent client param and header to client.
 
 # 1.6.31, 2020-04-10
 

--- a/alertmuting.go
+++ b/alertmuting.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -23,10 +24,12 @@ func (c *Client) CreateAlertMutingRule(muteRequest *alertmuting.CreateUpdateAler
 	}
 
 	resp, err := c.doRequest("POST", AlertMutingRuleAPIURL, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -36,6 +39,7 @@ func (c *Client) CreateAlertMutingRule(muteRequest *alertmuting.CreateUpdateAler
 	finalRule := &alertmuting.AlertMutingRule{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalRule)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalRule, err
 }
@@ -43,16 +47,18 @@ func (c *Client) CreateAlertMutingRule(muteRequest *alertmuting.CreateUpdateAler
 // DeleteAlertMutingRule deletes an alert muting rule.
 func (c *Client) DeleteAlertMutingRule(name string) error {
 	resp, err := c.doRequest("DELETE", AlertMutingRuleAPIURL+"/"+name, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return nil
 }
@@ -60,10 +66,12 @@ func (c *Client) DeleteAlertMutingRule(name string) error {
 // GetAlertMutingRule gets an alert muting rule.
 func (c *Client) GetAlertMutingRule(id string) (*alertmuting.AlertMutingRule, error) {
 	resp, err := c.doRequest("GET", AlertMutingRuleAPIURL+"/"+id, nil, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -73,6 +81,7 @@ func (c *Client) GetAlertMutingRule(id string) (*alertmuting.AlertMutingRule, er
 	finalRule := &alertmuting.AlertMutingRule{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalRule)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalRule, err
 }
@@ -85,10 +94,12 @@ func (c *Client) UpdateAlertMutingRule(id string, muteRequest *alertmuting.Creat
 	}
 
 	resp, err := c.doRequest("PUT", AlertMutingRuleAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -98,6 +109,7 @@ func (c *Client) UpdateAlertMutingRule(id string, muteRequest *alertmuting.Creat
 	finalRule := &alertmuting.AlertMutingRule{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalRule)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalRule, err
 }
@@ -111,15 +123,17 @@ func (c *Client) SearchAlertMutingRules(include string, limit int, name string, 
 	params.Add("offset", strconv.Itoa(offset))
 
 	resp, err := c.doRequest("GET", AlertMutingRuleAPIURL, params, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	finalRules := &alertmuting.SearchResult{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalRules)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalRules, err
 }

--- a/aws_cloudwatch_integration.go
+++ b/aws_cloudwatch_integration.go
@@ -18,11 +18,12 @@ func (c *Client) CreateAWSCloudWatchIntegration(acwi *integration.AwsCloudWatchI
 	}
 
 	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -39,11 +40,12 @@ func (c *Client) CreateAWSCloudWatchIntegration(acwi *integration.AwsCloudWatchI
 // GetAWSCloudWatchIntegration retrieves an AWS CloudWatch integration.
 func (c *Client) GetAWSCloudWatchIntegration(id string) (*integration.AwsCloudWatchIntegration, error) {
 	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -65,11 +67,12 @@ func (c *Client) UpdateAWSCloudWatchIntegration(id string, acwi *integration.Aws
 	}
 
 	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -86,11 +89,12 @@ func (c *Client) UpdateAWSCloudWatchIntegration(id string, acwi *integration.Aws
 // DeleteAWSCloudWatchIntegration deletes an AWS CloudWatch integration.
 func (c *Client) DeleteAWSCloudWatchIntegration(id string) error {
 	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)

--- a/aws_cloudwatch_integration.go
+++ b/aws_cloudwatch_integration.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -33,6 +34,7 @@ func (c *Client) CreateAWSCloudWatchIntegration(acwi *integration.AwsCloudWatchI
 	finalIntegration := integration.AwsCloudWatchIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -55,6 +57,7 @@ func (c *Client) GetAWSCloudWatchIntegration(id string) (*integration.AwsCloudWa
 	finalIntegration := integration.AwsCloudWatchIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -82,6 +85,7 @@ func (c *Client) UpdateAWSCloudWatchIntegration(id string, acwi *integration.Aws
 	finalIntegration := integration.AwsCloudWatchIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -100,6 +104,7 @@ func (c *Client) DeleteAWSCloudWatchIntegration(id string) error {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return err
 }

--- a/azure_integration.go
+++ b/azure_integration.go
@@ -18,11 +18,12 @@ func (c *Client) CreateAzureIntegration(acwi *integration.AzureIntegration) (*in
 	}
 
 	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -39,11 +40,12 @@ func (c *Client) CreateAzureIntegration(acwi *integration.AzureIntegration) (*in
 // GetAzureIntegration retrieves an Azure integration.
 func (c *Client) GetAzureIntegration(id string) (*integration.AzureIntegration, error) {
 	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -65,11 +67,12 @@ func (c *Client) UpdateAzureIntegration(id string, acwi *integration.AzureIntegr
 	}
 
 	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -86,11 +89,12 @@ func (c *Client) UpdateAzureIntegration(id string, acwi *integration.AzureIntegr
 // DeleteAzureIntegration deletes an Azure integration.
 func (c *Client) DeleteAzureIntegration(id string) error {
 	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)

--- a/azure_integration.go
+++ b/azure_integration.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -33,6 +34,7 @@ func (c *Client) CreateAzureIntegration(acwi *integration.AzureIntegration) (*in
 	finalIntegration := integration.AzureIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -55,6 +57,7 @@ func (c *Client) GetAzureIntegration(id string) (*integration.AzureIntegration, 
 	finalIntegration := integration.AzureIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -82,6 +85,7 @@ func (c *Client) UpdateAzureIntegration(id string, acwi *integration.AzureIntegr
 	finalIntegration := integration.AzureIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -100,6 +104,7 @@ func (c *Client) DeleteAzureIntegration(id string) error {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return err
 }

--- a/chart.go
+++ b/chart.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -39,6 +40,7 @@ func (c *Client) CreateChart(chartRequest *chart.CreateUpdateChartRequest) (*cha
 	finalChart := &chart.Chart{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalChart)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalChart, err
 }
@@ -56,6 +58,7 @@ func (c *Client) DeleteChart(id string) error {
 	if resp.StatusCode != http.StatusOK {
 		return errors.New("Unexpected status code: " + resp.Status)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return nil
 }
@@ -78,6 +81,7 @@ func (c *Client) GetChart(id string) (*chart.Chart, error) {
 	finalChart := &chart.Chart{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalChart)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalChart, err
 }
@@ -105,6 +109,7 @@ func (c *Client) UpdateChart(id string, chartRequest *chart.CreateUpdateChartReq
 	finalChart := &chart.Chart{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalChart)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalChart, err
 }
@@ -132,6 +137,7 @@ func (c *Client) SearchCharts(limit int, name string, offset int, tags string) (
 	finalCharts := &chart.SearchResult{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalCharts)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalCharts, err
 }

--- a/chart.go
+++ b/chart.go
@@ -24,10 +24,12 @@ func (c *Client) CreateChart(chartRequest *chart.CreateUpdateChartRequest) (*cha
 	}
 
 	resp, err := c.doRequest("POST", ChartAPIURL, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -44,11 +46,12 @@ func (c *Client) CreateChart(chartRequest *chart.CreateUpdateChartRequest) (*cha
 // DeleteChart deletes a chart.
 func (c *Client) DeleteChart(id string) error {
 	resp, err := c.doRequest("DELETE", ChartAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		return errors.New("Unexpected status code: " + resp.Status)
@@ -60,11 +63,12 @@ func (c *Client) DeleteChart(id string) error {
 // GetChart gets a chart.
 func (c *Client) GetChart(id string) (*chart.Chart, error) {
 	resp, err := c.doRequest("GET", ChartAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -86,10 +90,12 @@ func (c *Client) UpdateChart(id string, chartRequest *chart.CreateUpdateChartReq
 	}
 
 	resp, err := c.doRequest("PUT", ChartAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -116,11 +122,12 @@ func (c *Client) SearchCharts(limit int, name string, offset int, tags string) (
 	}
 
 	resp, err := c.doRequest("GET", ChartAPIURL, params, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	finalCharts := &chart.SearchResult{}
 

--- a/dashboard.go
+++ b/dashboard.go
@@ -25,10 +25,12 @@ func (c *Client) CreateDashboard(dashboardRequest *dashboard.CreateUpdateDashboa
 	}
 
 	resp, err := c.doRequest("POST", DashboardAPIURL, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -45,11 +47,12 @@ func (c *Client) CreateDashboard(dashboardRequest *dashboard.CreateUpdateDashboa
 // DeleteDashboard deletes a dashboard.
 func (c *Client) DeleteDashboard(id string) error {
 	resp, err := c.doRequest("DELETE", DashboardAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -62,11 +65,12 @@ func (c *Client) DeleteDashboard(id string) error {
 // GetDashboard gets a dashboard.
 func (c *Client) GetDashboard(id string) (*dashboard.Dashboard, error) {
 	resp, err := c.doRequest("GET", DashboardAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -88,10 +92,12 @@ func (c *Client) UpdateDashboard(id string, dashboardRequest *dashboard.CreateUp
 	}
 
 	resp, err := c.doRequest("PUT", DashboardAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -114,11 +120,12 @@ func (c *Client) SearchDashboard(limit int, name string, offset int, tags string
 	params.Add("tags", tags)
 
 	resp, err := c.doRequest("GET", DashboardAPIURL, params, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	finalDashboards := &dashboard.SearchResult{}
 

--- a/dashboard.go
+++ b/dashboard.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -40,6 +41,7 @@ func (c *Client) CreateDashboard(dashboardRequest *dashboard.CreateUpdateDashboa
 	finalDashboard := &dashboard.Dashboard{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDashboard)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDashboard, err
 }
@@ -58,6 +60,7 @@ func (c *Client) DeleteDashboard(id string) error {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return nil
 }
@@ -80,6 +83,7 @@ func (c *Client) GetDashboard(id string) (*dashboard.Dashboard, error) {
 	finalDashboard := &dashboard.Dashboard{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDashboard)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDashboard, err
 }
@@ -107,6 +111,7 @@ func (c *Client) UpdateDashboard(id string, dashboardRequest *dashboard.CreateUp
 	finalDashboard := &dashboard.Dashboard{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDashboard)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDashboard, err
 }
@@ -130,6 +135,7 @@ func (c *Client) SearchDashboard(limit int, name string, offset int, tags string
 	finalDashboards := &dashboard.SearchResult{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDashboards)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDashboards, err
 }

--- a/dashboardgroup.go
+++ b/dashboardgroup.go
@@ -30,10 +30,12 @@ func (c *Client) CreateDashboardGroup(dashboardGroupRequest *dashboard_group.Cre
 	}
 
 	resp, err := c.doRequest("POST", DashboardGroupAPIURL, params, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -50,11 +52,12 @@ func (c *Client) CreateDashboardGroup(dashboardGroupRequest *dashboard_group.Cre
 // DeleteDashboardGroup deletes a dashboard.
 func (c *Client) DeleteDashboardGroup(id string) error {
 	resp, err := c.doRequest("DELETE", DashboardGroupAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -67,11 +70,12 @@ func (c *Client) DeleteDashboardGroup(id string) error {
 // GetDashboardGroup gets a dashboard group.
 func (c *Client) GetDashboardGroup(id string) (*dashboard_group.DashboardGroup, error) {
 	resp, err := c.doRequest("GET", DashboardGroupAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -93,10 +97,12 @@ func (c *Client) UpdateDashboardGroup(id string, dashboardGroupRequest *dashboar
 	}
 
 	resp, err := c.doRequest("PUT", DashboardGroupAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -118,11 +124,12 @@ func (c *Client) SearchDashboardGroups(limit int, name string, offset int) (*das
 	params.Add("offset", strconv.Itoa(offset))
 
 	resp, err := c.doRequest("GET", DashboardGroupAPIURL, params, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	finalDashboardGroups := &dashboard_group.SearchResult{}
 

--- a/dashboardgroup.go
+++ b/dashboardgroup.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -45,6 +46,7 @@ func (c *Client) CreateDashboardGroup(dashboardGroupRequest *dashboard_group.Cre
 	finalDashboardGroup := &dashboard_group.DashboardGroup{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDashboardGroup)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDashboardGroup, err
 }
@@ -63,6 +65,7 @@ func (c *Client) DeleteDashboardGroup(id string) error {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return nil
 }
@@ -85,6 +88,7 @@ func (c *Client) GetDashboardGroup(id string) (*dashboard_group.DashboardGroup, 
 	finalDashboardGroup := &dashboard_group.DashboardGroup{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDashboardGroup)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDashboardGroup, err
 }
@@ -112,6 +116,7 @@ func (c *Client) UpdateDashboardGroup(id string, dashboardGroupRequest *dashboar
 	finalDashboardGroup := &dashboard_group.DashboardGroup{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDashboardGroup)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDashboardGroup, err
 }
@@ -134,6 +139,7 @@ func (c *Client) SearchDashboardGroups(limit int, name string, offset int) (*das
 	finalDashboardGroups := &dashboard_group.SearchResult{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDashboardGroups)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDashboardGroups, err
 }

--- a/datalink.go
+++ b/datalink.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -38,6 +39,7 @@ func (c *Client) CreateDataLink(dataLinkRequest *datalink.CreateUpdateDataLinkRe
 	finalDataLink := &datalink.DataLink{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDataLink)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDataLink, err
 }
@@ -58,6 +60,7 @@ func (c *Client) DeleteDataLink(id string) error {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return nil
 }
@@ -80,6 +83,7 @@ func (c *Client) GetDataLink(id string) (*datalink.DataLink, error) {
 	finalDataLink := &datalink.DataLink{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDataLink)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDataLink, err
 }
@@ -108,6 +112,7 @@ func (c *Client) UpdateDataLink(id string, dataLinkRequest *datalink.CreateUpdat
 	finalDataLink := &datalink.DataLink{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDataLink)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDataLink, err
 }
@@ -130,6 +135,7 @@ func (c *Client) SearchDataLinks(limit int, context string, offset int) (*datali
 	finalDataLinks := &datalink.SearchResults{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDataLinks)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDataLinks, err
 }

--- a/datalink.go
+++ b/datalink.go
@@ -23,10 +23,12 @@ func (c *Client) CreateDataLink(dataLinkRequest *datalink.CreateUpdateDataLinkRe
 	}
 
 	resp, err := c.doRequest("POST", DataLinkAPIURL, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -43,11 +45,12 @@ func (c *Client) CreateDataLink(dataLinkRequest *datalink.CreateUpdateDataLinkRe
 // DeleteDataLink deletes a data link.
 func (c *Client) DeleteDataLink(id string) error {
 	resp, err := c.doRequest("DELETE", DataLinkAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	// The API returns a 200 here, which I think is a mistake so covering for
 	// future changes.
@@ -62,10 +65,12 @@ func (c *Client) DeleteDataLink(id string) error {
 // GetDataLink gets a data link.
 func (c *Client) GetDataLink(id string) (*datalink.DataLink, error) {
 	resp, err := c.doRequest("GET", DataLinkAPIURL+"/"+id, nil, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -88,10 +93,12 @@ func (c *Client) UpdateDataLink(id string, dataLinkRequest *datalink.CreateUpdat
 
 	encodedName := url.PathEscape(id)
 	resp, err := c.doRequest("PUT", DataLinkAPIURL+"/"+encodedName, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -113,11 +120,12 @@ func (c *Client) SearchDataLinks(limit int, context string, offset int) (*datali
 	params.Add("offset", strconv.Itoa(offset))
 
 	resp, err := c.doRequest("GET", DataLinkAPIURL, params, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	finalDataLinks := &datalink.SearchResults{}
 

--- a/detector.go
+++ b/detector.go
@@ -23,10 +23,12 @@ func (c *Client) CreateDetector(detectorRequest *detector.CreateUpdateDetectorRe
 	}
 
 	resp, err := c.doRequest("POST", DetectorAPIURL, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -43,11 +45,12 @@ func (c *Client) CreateDetector(detectorRequest *detector.CreateUpdateDetectorRe
 // DeleteDetector deletes a detector.
 func (c *Client) DeleteDetector(id string) error {
 	resp, err := c.doRequest("DELETE", DetectorAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -65,10 +68,12 @@ func (c *Client) DisableDetector(id string, labels []string) error {
 	}
 
 	resp, err := c.doRequest("PUT", DetectorAPIURL+"/"+id+"/disable", nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -86,10 +91,12 @@ func (c *Client) EnableDetector(id string, labels []string) error {
 	}
 
 	resp, err := c.doRequest("PUT", DetectorAPIURL+"/"+id+"/enable", nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -102,10 +109,12 @@ func (c *Client) EnableDetector(id string, labels []string) error {
 // GetDetector gets a detector.
 func (c *Client) GetDetector(id string) (*detector.Detector, error) {
 	resp, err := c.doRequest("GET", DetectorAPIURL+"/"+id, nil, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -129,10 +138,12 @@ func (c *Client) UpdateDetector(id string, detectorRequest *detector.CreateUpdat
 	}
 
 	resp, err := c.doRequest("PUT", DetectorAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -157,11 +168,12 @@ func (c *Client) SearchDetectors(limit int, name string, offset int, tags string
 	}
 
 	resp, err := c.doRequest("GET", DetectorAPIURL, params, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	finalDetectors := &detector.SearchResults{}
 
@@ -178,10 +190,12 @@ func (c *Client) GetDetectorEvents(id string, from int, to int, offset int, limi
 	params.Add("offset", strconv.Itoa(offset))
 	params.Add("limit", strconv.Itoa(limit))
 	resp, err := c.doRequest("GET", DetectorAPIURL+"/"+id+"/events", params, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -203,10 +217,12 @@ func (c *Client) GetDetectorIncidents(id string, offset int, limit int) ([]*dete
 	params.Add("offset", strconv.Itoa(offset))
 	params.Add("limit", strconv.Itoa(limit))
 	resp, err := c.doRequest("GET", DetectorAPIURL+"/"+id+"/incidents", params, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)

--- a/detector.go
+++ b/detector.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -38,6 +39,7 @@ func (c *Client) CreateDetector(detectorRequest *detector.CreateUpdateDetectorRe
 	finalDetector := &detector.Detector{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDetector)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDetector, err
 }
@@ -56,6 +58,7 @@ func (c *Client) DeleteDetector(id string) error {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return nil
 }
@@ -79,6 +82,7 @@ func (c *Client) DisableDetector(id string, labels []string) error {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return nil
 }
@@ -102,6 +106,7 @@ func (c *Client) EnableDetector(id string, labels []string) error {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return nil
 }
@@ -124,9 +129,8 @@ func (c *Client) GetDetector(id string) (*detector.Detector, error) {
 	finalDetector := &detector.Detector{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDetector)
-	if err != nil {
-		fmt.Printf("+%v", err)
-	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
+
 	return finalDetector, err
 }
 
@@ -153,11 +157,12 @@ func (c *Client) UpdateDetector(id string, detectorRequest *detector.CreateUpdat
 	finalDetector := &detector.Detector{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDetector)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDetector, err
 }
 
-// SearchDetector searches for detectors, given a query string in `name`.
+// SearchDetectors searches for detectors, given a query string in `name`.
 func (c *Client) SearchDetectors(limit int, name string, offset int, tags string) (*detector.SearchResults, error) {
 	params := url.Values{}
 	params.Add("limit", strconv.Itoa(limit))
@@ -178,6 +183,7 @@ func (c *Client) SearchDetectors(limit int, name string, offset int, tags string
 	finalDetectors := &detector.SearchResults{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDetectors)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDetectors, err
 }
@@ -205,9 +211,8 @@ func (c *Client) GetDetectorEvents(id string, from int, to int, offset int, limi
 	var events []*detector.Event
 
 	err = json.NewDecoder(resp.Body).Decode(&events)
-	if err != nil {
-		fmt.Printf("+%v", err)
-	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
+
 	return events, err
 }
 
@@ -232,8 +237,7 @@ func (c *Client) GetDetectorIncidents(id string, offset int, limit int) ([]*dete
 	var incidents []*detector.Incident
 
 	err = json.NewDecoder(resp.Body).Decode(&incidents)
-	if err != nil {
-		fmt.Printf("+%v", err)
-	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
+
 	return incidents, err
 }

--- a/gcp_integration.go
+++ b/gcp_integration.go
@@ -18,11 +18,12 @@ func (c *Client) CreateGCPIntegration(gcpi *integration.GCPIntegration) (*integr
 	}
 
 	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -39,11 +40,12 @@ func (c *Client) CreateGCPIntegration(gcpi *integration.GCPIntegration) (*integr
 // GetGCPIntegration retrieves a GCP integration.
 func (c *Client) GetGCPIntegration(id string) (*integration.GCPIntegration, error) {
 	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -65,11 +67,12 @@ func (c *Client) UpdateGCPIntegration(id string, gcpi *integration.GCPIntegratio
 	}
 
 	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -86,11 +89,12 @@ func (c *Client) UpdateGCPIntegration(id string, gcpi *integration.GCPIntegratio
 // DeleteGCPIntegration deletes a GCP integration.
 func (c *Client) DeleteGCPIntegration(id string) error {
 	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)

--- a/gcp_integration.go
+++ b/gcp_integration.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -33,6 +34,7 @@ func (c *Client) CreateGCPIntegration(gcpi *integration.GCPIntegration) (*integr
 	finalIntegration := integration.GCPIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -55,6 +57,7 @@ func (c *Client) GetGCPIntegration(id string) (*integration.GCPIntegration, erro
 	finalIntegration := integration.GCPIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -82,6 +85,7 @@ func (c *Client) UpdateGCPIntegration(id string, gcpi *integration.GCPIntegratio
 	finalIntegration := integration.GCPIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -100,6 +104,7 @@ func (c *Client) DeleteGCPIntegration(id string) error {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return err
 }

--- a/integration.go
+++ b/integration.go
@@ -3,6 +3,7 @@ package signalfx
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 )
@@ -24,6 +25,7 @@ func (c *Client) DeleteIntegration(id string) error {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return nil
 }
@@ -46,6 +48,7 @@ func (c *Client) GetIntegration(id string) (map[string]interface{}, error) {
 	finalIntegration := make(map[string]interface{})
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalIntegration, err
 }

--- a/integration.go
+++ b/integration.go
@@ -13,11 +13,12 @@ const IntegrationAPIURL = "/v2/integration"
 // DeleteIntegration deletes an integration.
 func (c *Client) DeleteIntegration(id string) error {
 	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -30,11 +31,12 @@ func (c *Client) DeleteIntegration(id string) error {
 // GetIntegration gets a integration.
 func (c *Client) GetIntegration(id string) (map[string]interface{}, error) {
 	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)

--- a/jira_integration.go
+++ b/jira_integration.go
@@ -18,11 +18,12 @@ func (c *Client) CreateJiraIntegration(ji *integration.JiraIntegration) (*integr
 	}
 
 	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -39,11 +40,12 @@ func (c *Client) CreateJiraIntegration(ji *integration.JiraIntegration) (*integr
 // GetJiraIntegration retrieves an Jira integration.
 func (c *Client) GetJiraIntegration(id string) (*integration.JiraIntegration, error) {
 	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -65,11 +67,12 @@ func (c *Client) UpdateJiraIntegration(id string, ji *integration.JiraIntegratio
 	}
 
 	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -86,11 +89,12 @@ func (c *Client) UpdateJiraIntegration(id string, ji *integration.JiraIntegratio
 // DeleteJiraIntegration deletes an Jira integration.
 func (c *Client) DeleteJiraIntegration(id string) error {
 	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)

--- a/jira_integration.go
+++ b/jira_integration.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -33,6 +34,7 @@ func (c *Client) CreateJiraIntegration(ji *integration.JiraIntegration) (*integr
 	finalIntegration := integration.JiraIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -55,6 +57,7 @@ func (c *Client) GetJiraIntegration(id string) (*integration.JiraIntegration, er
 	finalIntegration := integration.JiraIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -82,6 +85,7 @@ func (c *Client) UpdateJiraIntegration(id string, ji *integration.JiraIntegratio
 	finalIntegration := integration.JiraIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -100,6 +104,7 @@ func (c *Client) DeleteJiraIntegration(id string) error {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return err
 }

--- a/metrics_metadata.go
+++ b/metrics_metadata.go
@@ -27,10 +27,12 @@ const TagAPIURL = "/v2/tag"
 // GetDimension gets a dimension.
 func (c *Client) GetDimension(key string, value string) (*metrics_metadata.Dimension, error) {
 	resp, err := c.doRequest("GET", DimensionAPIURL+"/"+key+"/"+value, nil, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -52,10 +54,12 @@ func (c *Client) UpdateDimension(key string, value string, dim *metrics_metadata
 	}
 
 	resp, err := c.doRequest("PUT", DimensionAPIURL+"/"+key+"/"+value, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -80,11 +84,12 @@ func (c *Client) SearchDimension(query string, orderBy string, limit int, offset
 	params.Add("offset", strconv.Itoa(offset))
 
 	resp, err := c.doRequest("GET", DimensionAPIURL, params, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	finalDimensions := &metrics_metadata.DimensionQueryResponseModel{}
 
@@ -102,11 +107,12 @@ func (c *Client) SearchMetric(query string, orderBy string, limit int, offset in
 	params.Add("offset", strconv.Itoa(offset))
 
 	resp, err := c.doRequest("GET", MetricAPIURL, params, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	finalMetrics := &metrics_metadata.RetrieveMetricMetadataResponseModel{}
 
@@ -118,10 +124,12 @@ func (c *Client) SearchMetric(query string, orderBy string, limit int, offset in
 // GetMetric retrieves a single metric by name.
 func (c *Client) GetMetric(name string) (*metrics_metadata.Metric, error) {
 	resp, err := c.doRequest("GET", MetricAPIURL+"/"+name, nil, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -138,10 +146,12 @@ func (c *Client) GetMetric(name string) (*metrics_metadata.Metric, error) {
 // GetMetricTimeSeries retrieves a metric time series by id.
 func (c *Client) GetMetricTimeSeries(id string) (*metrics_metadata.MetricTimeSeries, error) {
 	resp, err := c.doRequest("GET", MetricTimeSeriesAPIURL+"/"+id, nil, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -163,11 +173,12 @@ func (c *Client) SearchMetricTimeSeries(query string, orderBy string, limit int,
 	params.Add("offset", strconv.Itoa(offset))
 
 	resp, err := c.doRequest("GET", MetricTimeSeriesAPIURL, params, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	finalMTS := &metrics_metadata.MetricTimeSeriesRetrieveResponseModel{}
 
@@ -185,11 +196,12 @@ func (c *Client) SearchTag(query string, orderBy string, limit int, offset int) 
 	params.Add("offset", strconv.Itoa(offset))
 
 	resp, err := c.doRequest("GET", TagAPIURL, params, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	finalTags := &metrics_metadata.TagRetrieveResponseModel{}
 
@@ -201,10 +213,12 @@ func (c *Client) SearchTag(query string, orderBy string, limit int, offset int) 
 // GetTag gets a tag by name
 func (c *Client) GetTag(name string) (*metrics_metadata.Tag, error) {
 	resp, err := c.doRequest("GET", TagAPIURL+"/"+name, nil, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -220,11 +234,12 @@ func (c *Client) GetTag(name string) (*metrics_metadata.Tag, error) {
 // DeleteTag deletes a tag.
 func (c *Client) DeleteTag(id string) error {
 	resp, err := c.doRequest("DELETE", TagAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -242,10 +257,12 @@ func (c *Client) CreateUpdateTag(name string, cutr *metrics_metadata.CreateUpdat
 	}
 
 	resp, err := c.doRequest("PUT", TagAPIURL+"/"+name, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)

--- a/metrics_metadata.go
+++ b/metrics_metadata.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -69,6 +70,7 @@ func (c *Client) UpdateDimension(key string, value string, dim *metrics_metadata
 	finalDimension := &metrics_metadata.Dimension{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDimension)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDimension, err
 }
@@ -94,6 +96,7 @@ func (c *Client) SearchDimension(query string, orderBy string, limit int, offset
 	finalDimensions := &metrics_metadata.DimensionQueryResponseModel{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalDimensions)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalDimensions, err
 }
@@ -117,6 +120,7 @@ func (c *Client) SearchMetric(query string, orderBy string, limit int, offset in
 	finalMetrics := &metrics_metadata.RetrieveMetricMetadataResponseModel{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalMetrics)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalMetrics, err
 }
@@ -139,6 +143,7 @@ func (c *Client) GetMetric(name string) (*metrics_metadata.Metric, error) {
 	finalMetric := &metrics_metadata.Metric{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalMetric)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalMetric, err
 }
@@ -161,6 +166,8 @@ func (c *Client) GetMetricTimeSeries(id string) (*metrics_metadata.MetricTimeSer
 	finalMetricTimeSeries := &metrics_metadata.MetricTimeSeries{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalMetricTimeSeries)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
+
 	return finalMetricTimeSeries, err
 }
 
@@ -183,6 +190,7 @@ func (c *Client) SearchMetricTimeSeries(query string, orderBy string, limit int,
 	finalMTS := &metrics_metadata.MetricTimeSeriesRetrieveResponseModel{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalMTS)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalMTS, err
 }
@@ -206,6 +214,7 @@ func (c *Client) SearchTag(query string, orderBy string, limit int, offset int) 
 	finalTags := &metrics_metadata.TagRetrieveResponseModel{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalTags)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalTags, err
 }
@@ -228,6 +237,8 @@ func (c *Client) GetTag(name string) (*metrics_metadata.Tag, error) {
 	finalTag := &metrics_metadata.Tag{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalTag)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
+
 	return finalTag, err
 }
 
@@ -245,6 +256,7 @@ func (c *Client) DeleteTag(id string) error {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return nil
 }
@@ -272,6 +284,7 @@ func (c *Client) CreateUpdateTag(name string, cutr *metrics_metadata.CreateUpdat
 	finalTag := &metrics_metadata.Tag{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalTag)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalTag, err
 }

--- a/opsgenie_integration.go
+++ b/opsgenie_integration.go
@@ -18,11 +18,12 @@ func (c *Client) CreateOpsgenieIntegration(oi *integration.OpsgenieIntegration) 
 	}
 
 	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -39,11 +40,12 @@ func (c *Client) CreateOpsgenieIntegration(oi *integration.OpsgenieIntegration) 
 // GetOpsgenieIntegration retrieves an Opsgenie integration.
 func (c *Client) GetOpsgenieIntegration(id string) (*integration.OpsgenieIntegration, error) {
 	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -65,11 +67,12 @@ func (c *Client) UpdateOpsgenieIntegration(id string, oi *integration.OpsgenieIn
 	}
 
 	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -86,11 +89,12 @@ func (c *Client) UpdateOpsgenieIntegration(id string, oi *integration.OpsgenieIn
 // DeleteOpsgenieIntegration deletes an Opsgenie integration.
 func (c *Client) DeleteOpsgenieIntegration(id string) error {
 	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)

--- a/opsgenie_integration.go
+++ b/opsgenie_integration.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -33,6 +34,7 @@ func (c *Client) CreateOpsgenieIntegration(oi *integration.OpsgenieIntegration) 
 	finalIntegration := integration.OpsgenieIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -55,6 +57,7 @@ func (c *Client) GetOpsgenieIntegration(id string) (*integration.OpsgenieIntegra
 	finalIntegration := integration.OpsgenieIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -82,6 +85,7 @@ func (c *Client) UpdateOpsgenieIntegration(id string, oi *integration.OpsgenieIn
 	finalIntegration := integration.OpsgenieIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -100,6 +104,7 @@ func (c *Client) DeleteOpsgenieIntegration(id string) error {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return err
 }

--- a/organization.go
+++ b/organization.go
@@ -20,10 +20,12 @@ const OrganizationMembersAPIURL = "/v2/organization/members"
 // GetOrganization gets an organization.
 func (c *Client) GetOrganization(id string) (*organization.Organization, error) {
 	resp, err := c.doRequest("GET", OrganizationAPIURL+"/"+id, nil, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -40,10 +42,12 @@ func (c *Client) GetOrganization(id string) (*organization.Organization, error) 
 // GetMember gets a member.
 func (c *Client) GetMember(id string) (*organization.Member, error) {
 	resp, err := c.doRequest("GET", OrganizationMemberAPIURL+"/"+id, nil, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -60,11 +64,12 @@ func (c *Client) GetMember(id string) (*organization.Member, error) {
 // DeleteMember deletes a detector.
 func (c *Client) DeleteMember(id string) error {
 	resp, err := c.doRequest("DELETE", OrganizationMemberAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -82,10 +87,12 @@ func (c *Client) InviteMember(inviteRequest *organization.CreateUpdateMemberRequ
 	}
 
 	resp, err := c.doRequest("POST", OrganizationMemberAPIURL, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -107,10 +114,12 @@ func (c *Client) InviteMembers(inviteRequest *organization.InviteMembersRequest)
 	}
 
 	resp, err := c.doRequest("POST", OrganizationMembersAPIURL, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -133,11 +142,12 @@ func (c *Client) GetOrganizationMembers(limit int, query string, offset int, ord
 	params.Add("orderBy", orderBy)
 
 	resp, err := c.doRequest("GET", OrganizationMemberAPIURL, params, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	finalMembers := &organization.MemberSearchResults{}
 

--- a/organization.go
+++ b/organization.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -35,6 +36,7 @@ func (c *Client) GetOrganization(id string) (*organization.Organization, error) 
 	finalOrganization := &organization.Organization{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalOrganization)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalOrganization, err
 }
@@ -57,6 +59,7 @@ func (c *Client) GetMember(id string) (*organization.Member, error) {
 	finalMember := &organization.Member{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalMember)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalMember, err
 }
@@ -75,6 +78,7 @@ func (c *Client) DeleteMember(id string) error {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return nil
 }
@@ -102,6 +106,7 @@ func (c *Client) InviteMember(inviteRequest *organization.CreateUpdateMemberRequ
 	finalMember := &organization.Member{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalMember)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalMember, err
 }
@@ -129,6 +134,7 @@ func (c *Client) InviteMembers(inviteRequest *organization.InviteMembersRequest)
 	finalMembers := &organization.InviteMembersRequest{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalMembers)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalMembers, err
 }
@@ -152,6 +158,7 @@ func (c *Client) GetOrganizationMembers(limit int, query string, offset int, ord
 	finalMembers := &organization.MemberSearchResults{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalMembers)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalMembers, err
 }

--- a/orgtoken.go
+++ b/orgtoken.go
@@ -23,10 +23,12 @@ func (c *Client) CreateOrgToken(tokenRequest *orgtoken.CreateUpdateTokenRequest)
 	}
 
 	resp, err := c.doRequest("POST", TokenAPIURL, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -44,11 +46,12 @@ func (c *Client) CreateOrgToken(tokenRequest *orgtoken.CreateUpdateTokenRequest)
 func (c *Client) DeleteOrgToken(name string) error {
 	encodedName := url.PathEscape(name)
 	resp, err := c.doRequest("DELETE", TokenAPIURL+"/"+encodedName, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -62,10 +65,12 @@ func (c *Client) DeleteOrgToken(name string) error {
 func (c *Client) GetOrgToken(id string) (*orgtoken.Token, error) {
 	encodedName := url.PathEscape(id)
 	resp, err := c.doRequest("GET", TokenAPIURL+"/"+encodedName, nil, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -88,10 +93,12 @@ func (c *Client) UpdateOrgToken(id string, tokenRequest *orgtoken.CreateUpdateTo
 
 	encodedName := url.PathEscape(id)
 	resp, err := c.doRequest("PUT", TokenAPIURL+"/"+encodedName, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -113,11 +120,12 @@ func (c *Client) SearchOrgTokens(limit int, name string, offset int) (*orgtoken.
 	params.Add("offset", strconv.Itoa(offset))
 
 	resp, err := c.doRequest("GET", TokenAPIURL, params, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	finalTokens := &orgtoken.SearchResults{}
 

--- a/orgtoken.go
+++ b/orgtoken.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -38,6 +39,7 @@ func (c *Client) CreateOrgToken(tokenRequest *orgtoken.CreateUpdateTokenRequest)
 	finalToken := &orgtoken.Token{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalToken)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalToken, err
 }
@@ -57,11 +59,12 @@ func (c *Client) DeleteOrgToken(name string) error {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return nil
 }
 
-// GetToken gets a token.
+// GetOrgToken gets a token.
 func (c *Client) GetOrgToken(id string) (*orgtoken.Token, error) {
 	encodedName := url.PathEscape(id)
 	resp, err := c.doRequest("GET", TokenAPIURL+"/"+encodedName, nil, nil)
@@ -80,11 +83,12 @@ func (c *Client) GetOrgToken(id string) (*orgtoken.Token, error) {
 	finalToken := &orgtoken.Token{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalToken)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalToken, err
 }
 
-// UpdateToken updates a token.
+// UpdateOrgToken updates a token.
 func (c *Client) UpdateOrgToken(id string, tokenRequest *orgtoken.CreateUpdateTokenRequest) (*orgtoken.Token, error) {
 	payload, err := json.Marshal(tokenRequest)
 	if err != nil {
@@ -108,11 +112,12 @@ func (c *Client) UpdateOrgToken(id string, tokenRequest *orgtoken.CreateUpdateTo
 	finalToken := &orgtoken.Token{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalToken)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalToken, err
 }
 
-// SearchToken searches for tokens given a query string in `name`.
+// SearchOrgToken searches for tokens given a query string in `name`.
 func (c *Client) SearchOrgTokens(limit int, name string, offset int) (*orgtoken.SearchResults, error) {
 	params := url.Values{}
 	params.Add("limit", strconv.Itoa(limit))
@@ -130,6 +135,7 @@ func (c *Client) SearchOrgTokens(limit int, name string, offset int) (*orgtoken.
 	finalTokens := &orgtoken.SearchResults{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalTokens)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalTokens, err
 }

--- a/pagerduty_integration.go
+++ b/pagerduty_integration.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -33,6 +34,7 @@ func (c *Client) CreatePagerDutyIntegration(pdi *integration.PagerDutyIntegratio
 	finalIntegration := integration.PagerDutyIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -55,6 +57,7 @@ func (c *Client) GetPagerDutyIntegration(id string) (*integration.PagerDutyInteg
 	finalIntegration := integration.PagerDutyIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -82,6 +85,7 @@ func (c *Client) UpdatePagerDutyIntegration(id string, pdi *integration.PagerDut
 	finalIntegration := integration.PagerDutyIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -100,6 +104,7 @@ func (c *Client) DeletePagerDutyIntegration(id string) error {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return err
 }

--- a/pagerduty_integration.go
+++ b/pagerduty_integration.go
@@ -18,11 +18,12 @@ func (c *Client) CreatePagerDutyIntegration(pdi *integration.PagerDutyIntegratio
 	}
 
 	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -39,11 +40,12 @@ func (c *Client) CreatePagerDutyIntegration(pdi *integration.PagerDutyIntegratio
 // GetPagerDutyIntegration retrieves a PagerDuty integration.
 func (c *Client) GetPagerDutyIntegration(id string) (*integration.PagerDutyIntegration, error) {
 	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -65,11 +67,12 @@ func (c *Client) UpdatePagerDutyIntegration(id string, pdi *integration.PagerDut
 	}
 
 	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -86,11 +89,12 @@ func (c *Client) UpdatePagerDutyIntegration(id string, pdi *integration.PagerDut
 // DeletePagerDutyIntegration deletes a PagerDuty integration.
 func (c *Client) DeletePagerDutyIntegration(id string) error {
 	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)

--- a/sessiontoken.go
+++ b/sessiontoken.go
@@ -23,10 +23,12 @@ func (c *Client) CreateSessionToken(tokenRequest *sessiontoken.CreateTokenReques
 	// we need to explicitly pass an empty token (which means it wont get set in the header)
 	// the API accepts either no token or a valid token, but not an empty token.
 	resp, err := c.doRequestWithToken("POST", SessionTokenAPIURL, nil, bytes.NewReader(payload), "")
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -43,10 +45,12 @@ func (c *Client) CreateSessionToken(tokenRequest *sessiontoken.CreateTokenReques
 // DeleteOrgToken deletes a token.
 func (c *Client) DeleteSessionToken(token string) error {
 	resp, err := c.doRequestWithToken("DELETE", SessionTokenAPIURL, nil, nil, token)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)

--- a/sessiontoken.go
+++ b/sessiontoken.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -38,6 +39,7 @@ func (c *Client) CreateSessionToken(tokenRequest *sessiontoken.CreateTokenReques
 	sessionToken := &sessiontoken.Token{}
 
 	err = json.NewDecoder(resp.Body).Decode(sessionToken)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return sessionToken, err
 }
@@ -56,6 +58,7 @@ func (c *Client) DeleteSessionToken(token string) error {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return nil
 }

--- a/slack_integration.go
+++ b/slack_integration.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -33,6 +34,7 @@ func (c *Client) CreateSlackIntegration(si *integration.SlackIntegration) (*inte
 	finalIntegration := integration.SlackIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -55,6 +57,7 @@ func (c *Client) GetSlackIntegration(id string) (*integration.SlackIntegration, 
 	finalIntegration := integration.SlackIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -82,6 +85,7 @@ func (c *Client) UpdateSlackIntegration(id string, si *integration.SlackIntegrat
 	finalIntegration := integration.SlackIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -100,6 +104,7 @@ func (c *Client) DeleteSlackIntegration(id string) error {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return err
 }

--- a/slack_integration.go
+++ b/slack_integration.go
@@ -18,11 +18,12 @@ func (c *Client) CreateSlackIntegration(si *integration.SlackIntegration) (*inte
 	}
 
 	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -39,11 +40,12 @@ func (c *Client) CreateSlackIntegration(si *integration.SlackIntegration) (*inte
 // GetSlackIntegration retrieves a Slack integration.
 func (c *Client) GetSlackIntegration(id string) (*integration.SlackIntegration, error) {
 	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -65,11 +67,12 @@ func (c *Client) UpdateSlackIntegration(id string, si *integration.SlackIntegrat
 	}
 
 	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -86,11 +89,12 @@ func (c *Client) UpdateSlackIntegration(id string, si *integration.SlackIntegrat
 // DeleteSlackIntegration deletes a Slack integration.
 func (c *Client) DeleteSlackIntegration(id string) error {
 	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)

--- a/team.go
+++ b/team.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -39,6 +40,7 @@ func (c *Client) CreateTeam(t *team.CreateUpdateTeamRequest) (*team.Team, error)
 	finalTeam := &team.Team{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalTeam)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalTeam, err
 }
@@ -56,6 +58,7 @@ func (c *Client) DeleteTeam(id string) error {
 	if resp.StatusCode != http.StatusNoContent {
 		return errors.New("Unexpected status code: " + resp.Status)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return nil
 }
@@ -77,6 +80,7 @@ func (c *Client) GetTeam(id string) (*team.Team, error) {
 	finalTeam := &team.Team{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalTeam)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalTeam, err
 }
@@ -103,6 +107,7 @@ func (c *Client) UpdateTeam(id string, t *team.CreateUpdateTeamRequest) (*team.T
 	finalTeam := &team.Team{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalTeam)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalTeam, err
 }
@@ -126,6 +131,7 @@ func (c *Client) SearchTeam(limit int, name string, offset int, tags string) (*t
 	finalTeams := &team.SearchResults{}
 
 	err = json.NewDecoder(resp.Body).Decode(finalTeams)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return finalTeams, err
 }

--- a/team.go
+++ b/team.go
@@ -24,10 +24,12 @@ func (c *Client) CreateTeam(t *team.CreateUpdateTeamRequest) (*team.Team, error)
 	}
 
 	resp, err := c.doRequest("POST", TeamAPIURL, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -44,11 +46,12 @@ func (c *Client) CreateTeam(t *team.CreateUpdateTeamRequest) (*team.Team, error)
 // DeleteTeam deletes a team.
 func (c *Client) DeleteTeam(id string) error {
 	resp, err := c.doRequest("DELETE", TeamAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		return errors.New("Unexpected status code: " + resp.Status)
@@ -60,11 +63,12 @@ func (c *Client) DeleteTeam(id string) error {
 // GetTeam gets a team.
 func (c *Client) GetTeam(id string) (*team.Team, error) {
 	resp, err := c.doRequest("GET", TeamAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return nil, fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
@@ -85,10 +89,12 @@ func (c *Client) UpdateTeam(id string, t *team.CreateUpdateTeamRequest) (*team.T
 	}
 
 	resp, err := c.doRequest("PUT", TeamAPIURL+"/"+id, nil, bytes.NewReader(payload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return nil, fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
@@ -110,11 +116,12 @@ func (c *Client) SearchTeam(limit int, name string, offset int, tags string) (*t
 	params.Add("tags", tags)
 
 	resp, err := c.doRequest("GET", TeamAPIURL, params, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	finalTeams := &team.SearchResults{}
 

--- a/victor_ops_integration.go
+++ b/victor_ops_integration.go
@@ -18,11 +18,12 @@ func (c *Client) CreateVictorOpsIntegration(oi *integration.VictorOpsIntegration
 	}
 
 	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -39,11 +40,12 @@ func (c *Client) CreateVictorOpsIntegration(oi *integration.VictorOpsIntegration
 // GetVictorOpsIntegration retrieves an VictorOps integration.
 func (c *Client) GetVictorOpsIntegration(id string) (*integration.VictorOpsIntegration, error) {
 	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -65,11 +67,12 @@ func (c *Client) UpdateVictorOpsIntegration(id string, oi *integration.VictorOps
 	}
 
 	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -86,11 +89,12 @@ func (c *Client) UpdateVictorOpsIntegration(id string, oi *integration.VictorOps
 // DeleteVictorOpsIntegration deletes an VictorOps integration.
 func (c *Client) DeleteVictorOpsIntegration(id string) error {
 	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)

--- a/victor_ops_integration.go
+++ b/victor_ops_integration.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -33,6 +34,7 @@ func (c *Client) CreateVictorOpsIntegration(oi *integration.VictorOpsIntegration
 	finalIntegration := integration.VictorOpsIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -55,6 +57,7 @@ func (c *Client) GetVictorOpsIntegration(id string) (*integration.VictorOpsInteg
 	finalIntegration := integration.VictorOpsIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -82,6 +85,7 @@ func (c *Client) UpdateVictorOpsIntegration(id string, oi *integration.VictorOps
 	finalIntegration := integration.VictorOpsIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -100,6 +104,7 @@ func (c *Client) DeleteVictorOpsIntegration(id string) error {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return err
 }

--- a/webhook_integration.go
+++ b/webhook_integration.go
@@ -18,11 +18,12 @@ func (c *Client) CreateWebhookIntegration(oi *integration.WebhookIntegration) (*
 	}
 
 	resp, err := c.doRequest("POST", IntegrationAPIURL, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -39,11 +40,12 @@ func (c *Client) CreateWebhookIntegration(oi *integration.WebhookIntegration) (*
 // GetWebhookIntegration retrieves an Webhook integration.
 func (c *Client) GetWebhookIntegration(id string) (*integration.WebhookIntegration, error) {
 	resp, err := c.doRequest("GET", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -65,11 +67,12 @@ func (c *Client) UpdateWebhookIntegration(id string, oi *integration.WebhookInte
 	}
 
 	resp, err := c.doRequest("PUT", IntegrationAPIURL+"/"+id, nil, bytes.NewReader(payload))
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := ioutil.ReadAll(resp.Body)
@@ -86,11 +89,12 @@ func (c *Client) UpdateWebhookIntegration(id string, oi *integration.WebhookInte
 // DeleteWebhookIntegration deletes an Webhook integration.
 func (c *Client) DeleteWebhookIntegration(id string) error {
 	resp, err := c.doRequest("DELETE", IntegrationAPIURL+"/"+id, nil, nil)
-
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		message, _ := ioutil.ReadAll(resp.Body)

--- a/webhook_integration.go
+++ b/webhook_integration.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -33,6 +34,7 @@ func (c *Client) CreateWebhookIntegration(oi *integration.WebhookIntegration) (*
 	finalIntegration := integration.WebhookIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -55,6 +57,7 @@ func (c *Client) GetWebhookIntegration(id string) (*integration.WebhookIntegrati
 	finalIntegration := integration.WebhookIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -82,6 +85,7 @@ func (c *Client) UpdateWebhookIntegration(id string, oi *integration.WebhookInte
 	finalIntegration := integration.WebhookIntegration{}
 
 	err = json.NewDecoder(resp.Body).Decode(&finalIntegration)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return &finalIntegration, err
 }
@@ -100,6 +104,7 @@ func (c *Client) DeleteWebhookIntegration(id string) error {
 		message, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
 	}
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return err
 }


### PR DESCRIPTION
# Summary
Makes the following changes
* More thoroughly ensures the body of a response is closed
* Does a final read of the body to empty it out, just in case (this wasn't being done for some bodies with no expected content)

# Motivation
There have been some reports of hanging in the Terraform provider and I decided to go over our HTTP client use with a fine-tooth comb. Turns out there are definitely some places where this could happen.

