### PR TITLE
Move go:generate comment out of writer template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # 1.6.38, Pending
 
+## Improvements
+
+* Removed the go:generate comment out of the writer codegen template to make it
+  easier to consume in external projects
+
 # 1.6.37, 2020-05-18
 
 ## Improvements

--- a/writer/internal.go
+++ b/writer/internal.go
@@ -25,6 +25,8 @@
 // point.
 package writer
 
+//go:generate sh -c "cd template && ./gen.sh"
+
 import (
 	"context"
 

--- a/writer/template/gen.sh
+++ b/writer/template/gen.sh
@@ -21,5 +21,4 @@ sed -i'' -e 's/instance\(s\?\)_/trace_span\1_/' ../span_writer.gen.go
 
 
 # Common cleanup
-sed -i'' -e '/go:generate/d' ../*.gen.go
 goimports -w ../*.gen.go

--- a/writer/template/writer.go
+++ b/writer/template/writer.go
@@ -10,8 +10,6 @@ import (
 	"github.com/signalfx/golib/v3/sfxclient"
 )
 
-//go:generate sh ./gen.sh
-
 // InstancePreprocessor is used to filter out or otherwise change instances
 // before being sent.  If the return value is false, the instance won't be
 // sent.


### PR DESCRIPTION
This will make it easier to use in external repos