### PR TITLE
Added MatchedNoTimeseries & GroupByMissingProperty

### DIFF
--- a/signalflow/messages/info.go
+++ b/signalflow/messages/info.go
@@ -6,10 +6,12 @@ import (
 )
 
 const (
-	JobRunningResolution = "JOB_RUNNING_RESOLUTION"
-	JobDetectedLag       = "JOB_DETECTED_LAG"
-	JobInitialMaxDelay   = "JOB_INITIAL_MAX_DELAY"
-	FindLimitedResultSet = "FIND_LIMITED_RESULT_SET"
+	JobRunningResolution    = "JOB_RUNNING_RESOLUTION"
+	JobDetectedLag          = "JOB_DETECTED_LAG"
+	JobInitialMaxDelay      = "JOB_INITIAL_MAX_DELAY"
+	FindLimitedResultSet    = "FIND_LIMITED_RESULT_SET"
+	FindMatchedNoTimeseries = "FIND_MATCHED_NO_TIMESERIES"
+	GroupByMissingProperty  = "GROUPBY_MISSING_PROPERTY"
 )
 
 type MessageBlock struct {


### PR DESCRIPTION
Added two more [info messages](https://developers.signalfx.com/signalflow_analytics/rest_api_messages/information_messages_specification.html).

These don't have `int` content, so I made them `bool`s like how it's done in [signalfx-python](https://github.com/signalfx/signalfx-python/blob/f37ec439fd80c744e0e51dfcc1fb2426dadb6d3a/signalfx/signalflow/computation.py#L206)