### PR TITLE
Fix property name test

### DIFF
--- a/signalflow/messages/info.go
+++ b/signalflow/messages/info.go
@@ -107,8 +107,11 @@ func (jm FindMatchedNoTimeseriesContents) MatchedNoTimeseriesQuery() string {
 type GroupByMissingPropertyContents map[string]interface{}
 
 func (jm GroupByMissingPropertyContents) GroupByMissingProperties() []string {
-	field, _ := jm["propertyNames"].([]string)
-	return field
+	propNames := make([]string, len(jm["propertyNames"].([]interface{})))
+	for i, v := range jm["propertyNames"].([]interface{}) {
+		propNames[i] = v.(string)
+	}
+	return propNames
 }
 
 // ExpiredTSIDMessage is received when a timeseries has expired and is no


### PR DESCRIPTION
# Summary
Fixes busted test

# Motivation
Missed this test being broken. Can't cast a `[]interface{}` directly without casting each item.

cc @shrivu-stripe 