### PR TITLE
Fix data races on shared Computation properties

### DIFF
--- a/signalflow/computation.go
+++ b/signalflow/computation.go
@@ -118,6 +118,8 @@ func (c *Computation) Resolution() time.Duration {
 	if err := c.waitForMetadata(func() bool { return c.resolutionMS != nil }); err != nil {
 		return 0
 	}
+	c.updateSignal.Lock()
+	defer c.updateSignal.Unlock()
 	return time.Duration(*c.resolutionMS) * time.Millisecond
 }
 
@@ -128,6 +130,8 @@ func (c *Computation) Lag() time.Duration {
 	if err := c.waitForMetadata(func() bool { return c.lagMS != nil }); err != nil {
 		return 0
 	}
+	c.updateSignal.Lock()
+	defer c.updateSignal.Unlock()
 	return time.Duration(*c.lagMS) * time.Millisecond
 }
 
@@ -138,6 +142,8 @@ func (c *Computation) MaxDelay() time.Duration {
 	if err := c.waitForMetadata(func() bool { return c.maxDelayMS != nil }); err != nil {
 		return 0
 	}
+	c.updateSignal.Lock()
+	defer c.updateSignal.Unlock()
 	return time.Duration(*c.maxDelayMS) * time.Millisecond
 }
 
@@ -148,6 +154,8 @@ func (c *Computation) MatchedSize() int {
 	if err := c.waitForMetadata(func() bool { return c.matchedSize != nil }); err != nil {
 		return 0
 	}
+	c.updateSignal.Lock()
+	defer c.updateSignal.Unlock()
 	return *c.matchedSize
 }
 
@@ -158,6 +166,8 @@ func (c *Computation) LimitSize() int {
 	if err := c.waitForMetadata(func() bool { return c.limitSize != nil }); err != nil {
 		return 0
 	}
+	c.updateSignal.Lock()
+	defer c.updateSignal.Unlock()
 	return *c.limitSize
 }
 
@@ -169,6 +179,8 @@ func (c *Computation) MatchedNoTimeseriesQuery() string {
 	if err := c.waitForMetadata(func() bool { return c.matchedNoTimeseriesQuery != nil }); err != nil {
 		return ""
 	}
+	c.updateSignal.Lock()
+	defer c.updateSignal.Unlock()
 	return *c.matchedNoTimeseriesQuery
 }
 
@@ -180,6 +192,8 @@ func (c *Computation) GroupByMissingProperties() []string {
 	if err := c.waitForMetadata(func() bool { return c.groupByMissingProperties != nil }); err != nil {
 		return nil
 	}
+	c.updateSignal.Lock()
+	defer c.updateSignal.Unlock()
 	return c.groupByMissingProperties
 }
 
@@ -190,6 +204,8 @@ func (c *Computation) TSIDMetadata(tsid idtool.ID) *messages.MetadataProperties 
 	if err := c.waitForMetadata(func() bool { return c.tsidMetadata[tsid] != nil }); err != nil {
 		return nil
 	}
+	c.updateSignal.Lock()
+	defer c.updateSignal.Unlock()
 	return c.tsidMetadata[tsid]
 }
 
@@ -223,7 +239,8 @@ func (c *Computation) watchMessages() {
 
 func (c *Computation) processMessage(m messages.Message) {
 	defer c.updateSignal.SignalAll()
-
+	c.updateSignal.Lock()
+	defer c.updateSignal.Unlock()
 	switch v := m.(type) {
 	case *messages.JobStartControlMessage:
 		c.handle = v.Handle


### PR DESCRIPTION
- Wrap computation reads and writes in updateSignal lock
- Fix panic when reading metadata while processData is writing

Resolves #96 

Before:
`~/signalfx-go/signalflow$ go test -race ./...`
<details>
  <summary>Click to expand test output</summary>

```
2020/06/19 13:03:41 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-0
==================
WARNING: DATA RACE
Write at 0x00c000170548 by goroutine 22:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).processMessage()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:243 +0x2d8
  github.com/signalfx/signalfx-go/signalflow.(*Computation).watchMessages()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:219 +0x1a1

Previous read at 0x00c000170548 by goroutine 8:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).Resolution.func1()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:118 +0x4c
  github.com/signalfx/signalfx-go/signalflow.(*Computation).waitForMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:106 +0xa9
  github.com/signalfx/signalfx-go/signalflow.(*Computation).Resolution()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:118 +0x5f
  github.com/signalfx/signalfx-go/signalflow.TestAuthenticationFlow()
      /Users/kerby.hughes/signalfx-go/signalflow/client_test.go:28 +0x3bc
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 22 (running) created at:
  github.com/signalfx/signalfx-go/signalflow.newComputation()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:83 +0x3e5
  github.com/signalfx/signalfx-go/signalflow.(*Client).Execute()
      /Users/kerby.hughes/signalfx-go/signalflow/client.go:288 +0x24a
  github.com/signalfx/signalfx-go/signalflow.TestAuthenticationFlow()
      /Users/kerby.hughes/signalfx-go/signalflow/client_test.go:23 +0x359
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 8 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:916 +0x65a
  testing.runTests.func1()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1157 +0xa8
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163
  testing.runTests()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1155 +0x523
  testing.(*M).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1072 +0x2eb
  main.main()
      _testmain.go:76 +0x222
==================
2020/06/19 13:03:41 read err: read tcp 127.0.0.1:56974->127.0.0.1:56975: use of closed network connection
--- FAIL: TestAuthenticationFlow (0.01s)
    testing.go:809: race detected during execution of test
2020/06/19 13:03:41 Executing SignalFlow program data('cpu.utilization').publish() with tsids [VRBNx2aVch0 OAcEu3tNfAM] and handle handle-0
==================
WARNING: DATA RACE
Write at 0x00c00009c7b8 by goroutine 42:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).processMessage()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:243 +0x2d8
  github.com/signalfx/signalfx-go/signalflow.(*Computation).watchMessages()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:219 +0x1a1

Previous read at 0x00c00009c7b8 by goroutine 28:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).Resolution.func1()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:118 +0x4c
  github.com/signalfx/signalfx-go/signalflow.(*Computation).waitForMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:106 +0xa9
  github.com/signalfx/signalfx-go/signalflow.(*Computation).Resolution()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:118 +0x5f
  github.com/signalfx/signalfx-go/signalflow.TestBasicComputation()
      /Users/kerby.hughes/signalfx-go/signalflow/client_test.go:76 +0x7fb
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 42 (running) created at:
  github.com/signalfx/signalfx-go/signalflow.newComputation()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:83 +0x3e5
  github.com/signalfx/signalfx-go/signalflow.(*Client).Execute()
      /Users/kerby.hughes/signalfx-go/signalflow/client.go:288 +0x24a
  github.com/signalfx/signalfx-go/signalflow.TestBasicComputation()
      /Users/kerby.hughes/signalfx-go/signalflow/client_test.go:70 +0x792
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 28 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:916 +0x65a
  testing.runTests.func1()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1157 +0xa8
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163
  testing.runTests()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1155 +0x523
  testing.(*M).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1072 +0x2eb
  main.main()
      _testmain.go:76 +0x222
==================
2020/06/19 13:03:42 read err: read tcp 127.0.0.1:56976->127.0.0.1:56977: use of closed network connection
--- FAIL: TestBasicComputation (1.01s)
    testing.go:809: race detected during execution of test
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-0
==================
WARNING: DATA RACE
Write at 0x00c00009c958 by goroutine 63:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).processMessage()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:243 +0x2d8
  github.com/signalfx/signalfx-go/signalflow.(*Computation).watchMessages()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:219 +0x1a1

Previous read at 0x00c00009c958 by goroutine 50:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).Resolution.func1()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:118 +0x4c
  github.com/signalfx/signalfx-go/signalflow.(*Computation).waitForMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:106 +0xa9
  github.com/signalfx/signalfx-go/signalflow.(*Computation).Resolution()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:118 +0x5f
  github.com/signalfx/signalfx-go/signalflow.TestMultipleComputations()
      /Users/kerby.hughes/signalfx-go/signalflow/client_test.go:99 +0x311
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 63 (running) created at:
  github.com/signalfx/signalfx-go/signalflow.newComputation()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:83 +0x3e5
  github.com/signalfx/signalfx-go/signalflow.(*Client).Execute()
      /Users/kerby.hughes/signalfx-go/signalflow/client.go:288 +0x24a
  github.com/signalfx/signalfx-go/signalflow.TestMultipleComputations()
      /Users/kerby.hughes/signalfx-go/signalflow/client_test.go:93 +0x5f1
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 50 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:916 +0x65a
  testing.runTests.func1()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1157 +0xa8
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163
  testing.runTests()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1155 +0x523
  testing.(*M).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1072 +0x2eb
  main.main()
      _testmain.go:76 +0x222
==================
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-1
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-2
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-3
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-4
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-5
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-6
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-7
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-8
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-9
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-10
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-11
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-12
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-13
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-14
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-15
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-16
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-17
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-18
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-19
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-20
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-21
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-22
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-23
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-24
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-25
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-26
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-27
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-28
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-29
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-30
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-31
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-32
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-33
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-34
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-35
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-36
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-37
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-38
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-39
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-40
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-41
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-42
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-43
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-44
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-45
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-46
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-47
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-48
2020/06/19 13:03:42 read err: websocket: close 1006 (abnormal closure): unexpected EOF
--- FAIL: TestMultipleComputations (0.05s)
    testing.go:809: race detected during execution of test
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-0
==================
WARNING: DATA RACE
Write at 0x00c0003cc548 by goroutine 24:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).processMessage()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:243 +0x2d8
  github.com/signalfx/signalfx-go/signalflow.(*Computation).watchMessages()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:219 +0x1a1

Previous read at 0x00c0003cc548 by goroutine 102:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).Resolution.func1()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:118 +0x4c
  github.com/signalfx/signalfx-go/signalflow.(*Computation).waitForMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:106 +0xa9
  github.com/signalfx/signalfx-go/signalflow.(*Computation).Resolution()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:118 +0x5f
  github.com/signalfx/signalfx-go/signalflow.TestShutdown()
      /Users/kerby.hughes/signalfx-go/signalflow/client_test.go:121 +0x2da
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 24 (running) created at:
  github.com/signalfx/signalfx-go/signalflow.newComputation()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:83 +0x3e5
  github.com/signalfx/signalfx-go/signalflow.(*Client).Execute()
      /Users/kerby.hughes/signalfx-go/signalflow/client.go:288 +0x24a
  github.com/signalfx/signalfx-go/signalflow.TestShutdown()
      /Users/kerby.hughes/signalfx-go/signalflow/client_test.go:114 +0x5f4
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 102 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:916 +0x65a
  testing.runTests.func1()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1157 +0xa8
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163
  testing.runTests()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1155 +0x523
  testing.(*M).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1072 +0x2eb
  main.main()
      _testmain.go:76 +0x222
==================
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-1
2020/06/19 13:03:42 read err: websocket: close 1006 (abnormal closure): unexpected EOF
--- FAIL: TestShutdown (0.00s)
    testing.go:809: race detected during execution of test
2020/06/19 13:03:42 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-0
==================
WARNING: DATA RACE
Write at 0x00c0003cc6e8 by goroutine 65:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).processMessage()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:243 +0x2d8
  github.com/signalfx/signalfx-go/signalflow.(*Computation).watchMessages()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:219 +0x1a1

Previous read at 0x00c0003cc6e8 by goroutine 42:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).Resolution.func1()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:118 +0x4c
  github.com/signalfx/signalfx-go/signalflow.(*Computation).waitForMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:106 +0xa9
  github.com/signalfx/signalfx-go/signalflow.(*Computation).Resolution()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:118 +0x5f
  github.com/signalfx/signalfx-go/signalflow.TestReconnect()
      /Users/kerby.hughes/signalfx-go/signalflow/client_test.go:145 +0x3ce
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 65 (running) created at:
  github.com/signalfx/signalfx-go/signalflow.newComputation()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:83 +0x3e5
  github.com/signalfx/signalfx-go/signalflow.(*Client).Execute()
      /Users/kerby.hughes/signalfx-go/signalflow/client.go:288 +0x24a
  github.com/signalfx/signalfx-go/signalflow.TestReconnect()
      /Users/kerby.hughes/signalfx-go/signalflow/client_test.go:140 +0x365
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 42 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:916 +0x65a
  testing.runTests.func1()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1157 +0xa8
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163
  testing.runTests()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1155 +0x523
  testing.(*M).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1072 +0x2eb
  main.main()
      _testmain.go:76 +0x222
==================
2020/06/19 13:03:42 read err: read tcp 127.0.0.1:56982->127.0.0.1:56983: use of closed network connection
2020/06/19 13:03:42 Error reading from SignalFlow websocket: websocket: close 1006 (abnormal closure): unexpected EOF
2020/06/19 13:03:47 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-1
==================
WARNING: DATA RACE
Write at 0x00c0002103a8 by goroutine 197:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).processMessage()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:243 +0x2d8
  github.com/signalfx/signalfx-go/signalflow.(*Computation).watchMessages()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:219 +0x1a1

Previous read at 0x00c0002103a8 by goroutine 42:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).Resolution.func1()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:118 +0x4c
  github.com/signalfx/signalfx-go/signalflow.(*Computation).waitForMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:106 +0xa9
  github.com/signalfx/signalfx-go/signalflow.(*Computation).Resolution()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:118 +0x5f
  github.com/signalfx/signalfx-go/signalflow.TestReconnect()
      /Users/kerby.hughes/signalfx-go/signalflow/client_test.go:170 +0xc64
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 197 (running) created at:
  github.com/signalfx/signalfx-go/signalflow.newComputation()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:83 +0x3e5
  github.com/signalfx/signalfx-go/signalflow.(*Client).Execute()
      /Users/kerby.hughes/signalfx-go/signalflow/client.go:288 +0x24a
  github.com/signalfx/signalfx-go/signalflow.TestReconnect()
      /Users/kerby.hughes/signalfx-go/signalflow/client_test.go:165 +0xc01
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 42 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:916 +0x65a
  testing.runTests.func1()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1157 +0xa8
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163
  testing.runTests()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1155 +0x523
  testing.(*M).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1072 +0x2eb
  main.main()
      _testmain.go:76 +0x222
==================
2020/06/19 13:03:47 [map[token:abcd type:authenticate] map[channel:ch-1 immediate:false maxDelay:0 program:data('cpu.utilization').publish() resolution:0 start:0 stop:0 timezone: type:execute] map[token:abcd type:authenticate] map[channel:ch-2 immediate:false maxDelay:0 program:data('cpu.utilization').publish() resolution:0 start:0 stop:0 timezone: type:execute]]
2020/06/19 13:03:47 read err: read tcp 127.0.0.1:56982->127.0.0.1:56985: use of closed network connection
--- FAIL: TestReconnect (5.01s)
    testing.go:809: race detected during execution of test
2020/06/19 13:03:47 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-0
==================
WARNING: DATA RACE
Write at 0x00c00009c208 by goroutine 137:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).processMessage()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:243 +0x2d8
  github.com/signalfx/signalfx-go/signalflow.(*Computation).watchMessages()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:219 +0x1a1

Previous read at 0x00c00009c208 by goroutine 242:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).Resolution.func1()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:118 +0x4c
  github.com/signalfx/signalfx-go/signalflow.(*Computation).waitForMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:106 +0xa9
  github.com/signalfx/signalfx-go/signalflow.(*Computation).Resolution()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:118 +0x5f
  github.com/signalfx/signalfx-go/signalflow.TestReconnectAfterBackendDown()
      /Users/kerby.hughes/signalfx-go/signalflow/client_test.go:213 +0x3ce
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 137 (running) created at:
  github.com/signalfx/signalfx-go/signalflow.newComputation()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:83 +0x3e5
  github.com/signalfx/signalfx-go/signalflow.(*Client).Execute()
      /Users/kerby.hughes/signalfx-go/signalflow/client.go:288 +0x24a
  github.com/signalfx/signalfx-go/signalflow.TestReconnectAfterBackendDown()
      /Users/kerby.hughes/signalfx-go/signalflow/client_test.go:208 +0x365
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 242 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:916 +0x65a
  testing.runTests.func1()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1157 +0xa8
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163
  testing.runTests()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1155 +0x523
  testing.(*M).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1072 +0x2eb
  main.main()
      _testmain.go:76 +0x222
==================
2020/06/19 13:03:47 read err: read tcp 127.0.0.1:56986->127.0.0.1:56987: use of closed network connection
2020/06/19 13:03:47 Error reading from SignalFlow websocket: websocket: close 1006 (abnormal closure): unexpected EOF
2020/06/19 13:03:52 Error connecting to SignalFlow websocket: could not connect Signalflow websocket: dial tcp 127.0.0.1:56986: connect: connection refused
2020/06/19 13:03:57 Error connecting to SignalFlow websocket: could not connect Signalflow websocket: dial tcp 127.0.0.1:56986: connect: connection refused
2020/06/19 13:04:02 Executing SignalFlow program data('cpu.utilization').publish() with tsids [] and handle handle-1
==================
WARNING: DATA RACE
Write at 0x00c0004c2618 by goroutine 226:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).processMessage()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:243 +0x2d8
  github.com/signalfx/signalfx-go/signalflow.(*Computation).watchMessages()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:219 +0x1a1

Previous read at 0x00c0004c2618 by goroutine 242:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).Resolution.func1()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:118 +0x4c
  github.com/signalfx/signalfx-go/signalflow.(*Computation).waitForMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:106 +0xa9
  github.com/signalfx/signalfx-go/signalflow.(*Computation).Resolution()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:118 +0x5f
  github.com/signalfx/signalfx-go/signalflow.TestReconnectAfterBackendDown()
      /Users/kerby.hughes/signalfx-go/signalflow/client_test.go:240 +0xc85
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 226 (running) created at:
  github.com/signalfx/signalfx-go/signalflow.newComputation()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:83 +0x3e5
  github.com/signalfx/signalfx-go/signalflow.(*Client).Execute()
      /Users/kerby.hughes/signalfx-go/signalflow/client.go:288 +0x24a
  github.com/signalfx/signalfx-go/signalflow.TestReconnectAfterBackendDown()
      /Users/kerby.hughes/signalfx-go/signalflow/client_test.go:235 +0xc22
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 242 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:916 +0x65a
  testing.runTests.func1()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1157 +0xa8
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163
  testing.runTests()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1155 +0x523
  testing.(*M).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1072 +0x2eb
  main.main()
      _testmain.go:76 +0x222
==================
2020/06/19 13:04:02 read err: read tcp 127.0.0.1:56986->127.0.0.1:56991: use of closed network connection
--- FAIL: TestReconnectAfterBackendDown (15.01s)
    testing.go:809: race detected during execution of test
==================
WARNING: DATA RACE
Write at 0x00c000440420 by goroutine 34:
  runtime.mapassign_fast64()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/runtime/map_fast64.go:92 +0x0
  github.com/signalfx/signalfx-go/signalflow.(*Computation).processMessage()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:271 +0x12e7
  github.com/signalfx/signalfx-go/signalflow.(*Computation).watchMessages()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:219 +0x1a1

Previous read at 0x00c000440420 by goroutine 133:
  runtime.mapaccess1_fast64()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/runtime/map_fast64.go:12 +0x0
  github.com/signalfx/signalfx-go/signalflow.(*Computation).TSIDMetadata.func1()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:190 +0x87
  github.com/signalfx/signalfx-go/signalflow.(*Computation).waitForMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:106 +0xa9
  github.com/signalfx/signalfx-go/signalflow.(*Computation).TSIDMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:190 +0x72
  github.com/signalfx/signalfx-go/signalflow.TestBuffersDataMessages()
      /Users/kerby.hughes/signalfx-go/signalflow/computation_test.go:52 +0x44a
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 34 (running) created at:
  github.com/signalfx/signalfx-go/signalflow.newComputation()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:83 +0x3e5
  github.com/signalfx/signalfx-go/signalflow.TestBuffersDataMessages()
      /Users/kerby.hughes/signalfx-go/signalflow/computation_test.go:37 +0x248
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 133 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:916 +0x65a
  testing.runTests.func1()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1157 +0xa8
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163
  testing.runTests()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1155 +0x523
  testing.(*M).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1072 +0x2eb
  main.main()
      _testmain.go:76 +0x222
==================
--- FAIL: TestBuffersDataMessages (0.00s)
    testing.go:809: race detected during execution of test
==================
WARNING: DATA RACE
Write at 0x00c0000b3b30 by goroutine 127:
  runtime.mapassign_fast64()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/runtime/map_fast64.go:92 +0x0
  github.com/signalfx/signalfx-go/signalflow.(*Computation).processMessage()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:271 +0x12e7
  github.com/signalfx/signalfx-go/signalflow.(*Computation).watchMessages()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:219 +0x1a1

Previous read at 0x00c0000b3b30 by goroutine 47:
  runtime.mapaccess1_fast64()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/runtime/map_fast64.go:12 +0x0
  github.com/signalfx/signalfx-go/signalflow.(*Computation).TSIDMetadata.func1()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:190 +0x87
  github.com/signalfx/signalfx-go/signalflow.(*Computation).waitForMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:106 +0xa9
  github.com/signalfx/signalfx-go/signalflow.(*Computation).TSIDMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:190 +0x72
  github.com/signalfx/signalfx-go/signalflow.TestBuffersExpiryMessages()
      /Users/kerby.hughes/signalfx-go/signalflow/computation_test.go:87 +0x44a
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 127 (running) created at:
  github.com/signalfx/signalfx-go/signalflow.newComputation()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:83 +0x3e5
  github.com/signalfx/signalfx-go/signalflow.TestBuffersExpiryMessages()
      /Users/kerby.hughes/signalfx-go/signalflow/computation_test.go:72 +0x248
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 47 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:916 +0x65a
  testing.runTests.func1()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1157 +0xa8
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163
  testing.runTests()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1155 +0x523
  testing.(*M).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1072 +0x2eb
  main.main()
      _testmain.go:76 +0x222
==================
--- FAIL: TestBuffersExpiryMessages (0.00s)
    testing.go:809: race detected during execution of test
==================
WARNING: DATA RACE
Write at 0x00c00009c548 by goroutine 70:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).processMessage()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:243 +0x2d8
  github.com/signalfx/signalfx-go/signalflow.(*Computation).watchMessages()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:219 +0x1a1

Previous read at 0x00c00009c548 by goroutine 58:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).Resolution.func1()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:118 +0x4c
  github.com/signalfx/signalfx-go/signalflow.(*Computation).waitForMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:106 +0xa9
  github.com/signalfx/signalfx-go/signalflow.(*Computation).Resolution()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:118 +0x5f
  github.com/signalfx/signalfx-go/signalflow.TestResolutionMetadata.func1()
      /Users/kerby.hughes/signalfx-go/signalflow/computation_test.go:125 +0x3c

Goroutine 70 (running) created at:
  github.com/signalfx/signalfx-go/signalflow.newComputation()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:83 +0x3e5
  github.com/signalfx/signalfx-go/signalflow.TestResolutionMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation_test.go:114 +0x239
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 58 (running) created at:
  github.com/signalfx/signalfx-go/signalflow.TestResolutionMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation_test.go:124 +0x315
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163
==================
--- FAIL: TestResolutionMetadata (0.00s)
    testing.go:809: race detected during execution of test
==================
WARNING: DATA RACE
Write at 0x00c0002807c8 by goroutine 222:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).processMessage()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:247 +0x471
  github.com/signalfx/signalfx-go/signalflow.(*Computation).watchMessages()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:219 +0x1a1

Previous read at 0x00c0002807c8 by goroutine 120:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).MaxDelay.func1()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:138 +0x4c
  github.com/signalfx/signalfx-go/signalflow.(*Computation).waitForMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:106 +0xa9
  github.com/signalfx/signalfx-go/signalflow.(*Computation).MaxDelay()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:138 +0x5f
  github.com/signalfx/signalfx-go/signalflow.TestMaxDelayMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation_test.go:159 +0x334
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 222 (running) created at:
  github.com/signalfx/signalfx-go/signalflow.newComputation()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:83 +0x3e5
  github.com/signalfx/signalfx-go/signalflow.TestMaxDelayMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation_test.go:145 +0x239
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 120 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:916 +0x65a
  testing.runTests.func1()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1157 +0xa8
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163
  testing.runTests()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1155 +0x523
  testing.(*M).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1072 +0x2eb
  main.main()
      _testmain.go:76 +0x222
==================
--- FAIL: TestMaxDelayMetadata (0.00s)
    testing.go:809: race detected during execution of test
==================
WARNING: DATA RACE
Write at 0x00c000280890 by goroutine 113:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).processMessage()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:245 +0x5c8
  github.com/signalfx/signalfx-go/signalflow.(*Computation).watchMessages()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:219 +0x1a1

Previous read at 0x00c000280890 by goroutine 8:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).Lag.func1()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:128 +0x4c
  github.com/signalfx/signalfx-go/signalflow.(*Computation).waitForMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:106 +0xa9
  github.com/signalfx/signalfx-go/signalflow.(*Computation).Lag()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:128 +0x5f
  github.com/signalfx/signalfx-go/signalflow.TestLagMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation_test.go:178 +0x331
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 113 (running) created at:
  github.com/signalfx/signalfx-go/signalflow.newComputation()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:83 +0x3e5
  github.com/signalfx/signalfx-go/signalflow.TestLagMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation_test.go:164 +0x239
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 8 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:916 +0x65a
  testing.runTests.func1()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1157 +0xa8
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163
  testing.runTests()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1155 +0x523
  testing.(*M).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1072 +0x2eb
  main.main()
      _testmain.go:76 +0x222
==================
--- FAIL: TestLagMetadata (0.00s)
    testing.go:809: race detected during execution of test
==================
WARNING: DATA RACE
Write at 0x00c000210be0 by goroutine 51:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).processMessage()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:249 +0xa54
  github.com/signalfx/signalfx-go/signalflow.(*Computation).watchMessages()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:219 +0x1a1

Previous read at 0x00c000210be0 by goroutine 99:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).MatchedSize.func1()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:148 +0x4f
  github.com/signalfx/signalfx-go/signalflow.(*Computation).waitForMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:106 +0xa9
  github.com/signalfx/signalfx-go/signalflow.(*Computation).MatchedSize()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:148 +0x5f
  github.com/signalfx/signalfx-go/signalflow.TestFindLimitedResultSetMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation_test.go:198 +0x334
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 51 (running) created at:
  github.com/signalfx/signalfx-go/signalflow.newComputation()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:83 +0x3e5
  github.com/signalfx/signalfx-go/signalflow.TestFindLimitedResultSetMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation_test.go:183 +0x239
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 99 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:916 +0x65a
  testing.runTests.func1()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1157 +0xa8
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163
  testing.runTests()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1155 +0x523
  testing.(*M).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1072 +0x2eb
  main.main()
      _testmain.go:76 +0x222
==================
--- FAIL: TestFindLimitedResultSetMetadata (0.00s)
    testing.go:809: race detected during execution of test
==================
WARNING: DATA RACE
Write at 0x00c000280980 by goroutine 81:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).processMessage()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:252 +0x784
  github.com/signalfx/signalfx-go/signalflow.(*Computation).watchMessages()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:219 +0x1a1

Previous read at 0x00c000280980 by goroutine 29:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).MatchedNoTimeseriesQuery.func1()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:169 +0x4f
  github.com/signalfx/signalfx-go/signalflow.(*Computation).waitForMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:106 +0xa9
  github.com/signalfx/signalfx-go/signalflow.(*Computation).MatchedNoTimeseriesQuery()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:169 +0x5f
  github.com/signalfx/signalfx-go/signalflow.TestMatchedNoTimeseriesQueryMetaData()
      /Users/kerby.hughes/signalfx-go/signalflow/computation_test.go:218 +0x334
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 81 (running) created at:
  github.com/signalfx/signalfx-go/signalflow.newComputation()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:83 +0x3e5
  github.com/signalfx/signalfx-go/signalflow.TestMatchedNoTimeseriesQueryMetaData()
      /Users/kerby.hughes/signalfx-go/signalflow/computation_test.go:204 +0x239
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 29 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:916 +0x65a
  testing.runTests.func1()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1157 +0xa8
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163
  testing.runTests()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1155 +0x523
  testing.(*M).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1072 +0x2eb
  main.main()
      _testmain.go:76 +0x222
==================
--- FAIL: TestMatchedNoTimeseriesQueryMetaData (0.00s)
    testing.go:809: race detected during execution of test
==================
WARNING: DATA RACE
Write at 0x00c000280a58 by goroutine 185:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).processMessage()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:254 +0x89e
  github.com/signalfx/signalfx-go/signalflow.(*Computation).watchMessages()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:219 +0x1a1

Previous read at 0x00c000280a58 by goroutine 115:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).GroupByMissingProperties.func1()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:180 +0x4f
  github.com/signalfx/signalfx-go/signalflow.(*Computation).waitForMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:106 +0xa9
  github.com/signalfx/signalfx-go/signalflow.(*Computation).GroupByMissingProperties()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:180 +0x5f
  github.com/signalfx/signalfx-go/signalflow.TestGroupByMissingPropertyMetaData()
      /Users/kerby.hughes/signalfx-go/signalflow/computation_test.go:237 +0x349
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 185 (running) created at:
  github.com/signalfx/signalfx-go/signalflow.newComputation()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:83 +0x3e5
  github.com/signalfx/signalfx-go/signalflow.TestGroupByMissingPropertyMetaData()
      /Users/kerby.hughes/signalfx-go/signalflow/computation_test.go:223 +0x248
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 115 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:916 +0x65a
  testing.runTests.func1()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1157 +0xa8
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163
  testing.runTests()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1155 +0x523
  testing.(*M).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1072 +0x2eb
  main.main()
      _testmain.go:76 +0x222
==================
--- FAIL: TestGroupByMissingPropertyMetaData (0.00s)
    testing.go:809: race detected during execution of test
==================
WARNING: DATA RACE
Write at 0x00c000280b48 by goroutine 202:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).processMessage()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:229 +0x10d8
  github.com/signalfx/signalfx-go/signalflow.(*Computation).watchMessages()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:219 +0x1a1

Previous read at 0x00c000280b48 by goroutine 161:
  github.com/signalfx/signalfx-go/signalflow.(*Computation).Handle.func1()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:94 +0x4f
  github.com/signalfx/signalfx-go/signalflow.(*Computation).waitForMetadata()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:106 +0xa9
  github.com/signalfx/signalfx-go/signalflow.(*Computation).Handle()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:94 +0x5f
  github.com/signalfx/signalfx-go/signalflow.TestHandle()
      /Users/kerby.hughes/signalfx-go/signalflow/computation_test.go:252 +0x328
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 202 (running) created at:
  github.com/signalfx/signalfx-go/signalflow.newComputation()
      /Users/kerby.hughes/signalfx-go/signalflow/computation.go:83 +0x3e5
  github.com/signalfx/signalfx-go/signalflow.TestHandle()
      /Users/kerby.hughes/signalfx-go/signalflow/computation_test.go:242 +0x239
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163

Goroutine 161 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:916 +0x65a
  testing.runTests.func1()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1157 +0xa8
  testing.tRunner()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:865 +0x163
  testing.runTests()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1155 +0x523
  testing.(*M).Run()
      /usr/local/Cellar/go@1.12/1.12.17/libexec/src/testing/testing.go:1072 +0x2eb
  main.main()
      _testmain.go:76 +0x222
==================
--- FAIL: TestHandle (0.00s)
    testing.go:809: race detected during execution of test
FAIL
FAIL	github.com/signalfx/signalfx-go/signalflow	22.478s
?   	github.com/signalfx/signalfx-go/signalflow/example	[no test files]
ok  	github.com/signalfx/signalfx-go/signalflow/messages	(cached)
```
</details>

With patch:
```
~/signalfx-go/signalflow$ go test -race ./...
ok  	github.com/signalfx/signalfx-go/signalflow	23.293s
?   	github.com/signalfx/signalfx-go/signalflow/example	[no test files]
ok  	github.com/signalfx/signalfx-go/signalflow/messages	1.142s
~/signalfx-go/signalflow$ 
```