### PR TITLE
signalflow: Handle race on client close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.7.6, Pending
+* Fix race condition in SignalFlow client Close operation that could cause
+  panics.
+
 # 1.7.5, 2020-06-11
 * Fix busted accessor.
 


### PR DESCRIPTION
Messages that came in after the channel closed were casuing a panic
by sending to a closed channel.  This will ensure no messages are
sent to a channel after it is closed on client shutdown.

Fixes #98.