### PR TITLE
signalflow: close computation data channel in writer goroutine

### DIFF
--- a/signalflow/computation.go
+++ b/signalflow/computation.go
@@ -225,7 +225,6 @@ func (c *Computation) watchMessages() {
 	for {
 		select {
 		case <-c.ctx.Done():
-			close(c.dataCh)
 			return
 		case m, ok := <-c.channel.Messages():
 			if !ok {
@@ -301,6 +300,7 @@ func (c *Computation) bufferDataMessages() {
 			}
 			select {
 			case <-c.ctx.Done():
+				close(c.dataCh)
 				return
 			case c.dataCh <- nextMessage:
 				nextMessage = nil


### PR DESCRIPTION
This helps prevent panics when shutting down a computation.

Fixes #98.