### PR TITLE
Add detector name to incident model

### DIFF
--- a/detector/model_incident.go
+++ b/detector/model_incident.go
@@ -5,6 +5,7 @@ type Incident struct {
 	AnomalyState string                  `json:"anomalyState,omitempty"`
 	DetectLabel  string                  `json:"detectLabel,omitempty"`
 	DetectorId   string                  `json:"detectorId,omitempty"`
+	DetectorName string                  `json:"detectorName,omitempty"`
 	Events       []*Event                `json:"events,omitempty"`
 	IncidentId   string                  `json:"incidentId,omitempty"`
 	Inputs       *map[string]interface{} `json:"inputs,omitempty"`


### PR DESCRIPTION
What it says on the tin.

This option actually isn't documented in the API, can it be? Looks like it is in fact there!

https://developers.signalfx.com/detectors_reference.html#operation/Retrieve%20Incidents%20Single%20Detector