### PR TITLE
Add new team fields

### DIFF
--- a/team/model_create_update_team_request.go
+++ b/team/model_create_update_team_request.go
@@ -18,4 +18,6 @@ type CreateUpdateTeamRequest struct {
 	// List of organization members IDs that belong to this team
 	Members           []string          `json:"members,omitempty"`
 	NotificationLists NotificationLists `json:"notificationLists,omitempty"`
+	DashboardGroups   []string          `json:"dashboardGroups,omitempty"`
+	Detectors         []string          `json:"detectors,omitempty"`
 }

--- a/team/model_team.go
+++ b/team/model_team.go
@@ -20,4 +20,6 @@ type Team struct {
 	// List of organization members IDs that belong to this team
 	Members           []string          `json:"members,omitempty"`
 	NotificationLists NotificationLists `json:"notificationLists,omitempty"`
+	DashboardGroups   []string          `json:"dashboardGroups,omitempty"`
+	Detectors         []string          `json:"detectors,omitempty"`
 }

--- a/testdata/fixtures/team/create_success.json
+++ b/testdata/fixtures/team/create_success.json
@@ -5,6 +5,12 @@
   "members": [
     "string"
   ],
+  "dashboardGroups": [
+    "string"
+  ],
+  "detectors": [
+    "string"
+  ],
   "notificationLists": {
     "default": [
       {

--- a/testdata/fixtures/team/get_success.json
+++ b/testdata/fixtures/team/get_success.json
@@ -5,6 +5,12 @@
   "members": [
     "string"
   ],
+  "dashboardGroups": [
+    "string"
+  ],
+  "detectors": [
+    "string"
+  ],
   "notificationLists": {
     "default": [
       {

--- a/testdata/fixtures/team/search_success.json
+++ b/testdata/fixtures/team/search_success.json
@@ -8,6 +8,12 @@
       "members": [
         "string"
       ],
+      "dashboardGroups": [
+        "string"
+      ],
+      "detectors": [
+        "string"
+      ],
       "notificationLists": {
         "default": [
           {

--- a/testdata/fixtures/team/update_success.json
+++ b/testdata/fixtures/team/update_success.json
@@ -5,6 +5,12 @@
   "members": [
     "string"
   ],
+  "dashboardGroups": [
+    "string"
+  ],
+  "detectors": [
+    "string"
+  ],
   "notificationLists": {
     "default": [
       {


### PR DESCRIPTION
# Summary
Adds `detectors` and `dashboardGroups` to team

# Motivation
Adding new methods, as manipulating these on detectors and dashboardgroups is deprecated.