### PR TITLE
Don't omit empty description for charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.7.10, 2020-08-06
+* Don't omit chart.description from JSON, as API doesn't clear it if absent. [#107](https://github.com/signalfx/signalfx-go/pull/107)
+
 # 1.7.9, 2020-08-06
 * Allow AWS poll rate to be an int64. [#106](https://github.com/signalfx/signalfx-go/pull/106)
 

--- a/chart/model_create_update_chart_request.go
+++ b/chart/model_create_update_chart_request.go
@@ -13,7 +13,7 @@ type CreateUpdateChartRequest struct {
 	// User-defined JSON object containing metadata
 	CustomProperties string `json:"customProperties,omitempty"`
 	// Description of the chart. This value appears underneath the chart name in the SignalFx web UI.
-	Description string `json:"description,omitempty"`
+	Description string `json:"description"`
 	// The displayed name of the chart in the dashboard
 	Name    string   `json:"name,omitempty"`
 	Options *Options `json:"options,omitempty"`


### PR DESCRIPTION
# Summary
What it says on the tin.

# Motivation
The API isn't clearing chart descriptions when this field is omitted, so send it explicitly to make sure that the lack of a description is honored.