### PR TITLE
Fix processing ControlMessage in signalflow.Computation

### DIFF
--- a/signalflow/computation.go
+++ b/signalflow/computation.go
@@ -244,7 +244,7 @@ func (c *Computation) processMessage(m messages.Message) {
 	case *messages.JobStartControlMessage:
 		c.handle = v.Handle
 	case *messages.BaseControlMessage:
-		switch v.Type() {
+		switch v.Event {
 		case messages.ChannelAbortEvent, messages.EndOfChannelEvent:
 			c.cancel()
 		}


### PR DESCRIPTION
This change fixes a switch statement in `signalflow.Computation.processMessage()` for incoming SignalFlow control messages, which should dispatch on Event (e.g  `CHANNEL_ABORT`, `END_OF_CHANNEL`), not Type, which is already determined in the outer type-switch. 

The bug meant a computation with a Stop time specified could never be understood to be completed when receiving the `END_OF_CHANNEL` or `CHANNEL_ABORT` control messages from the Signalflow API. We confirmed that a `Computation.Done()` will properly yield after receiving `END_OF_CHANNEL` with this fix.