### PR TITLE
Add channel to fake_backend program error message

### DIFF
--- a/signalflow/fake_backend.go
+++ b/signalflow/fake_backend.go
@@ -145,7 +145,7 @@ func (f *FakeBackend) handleMessage(ctx context.Context, message map[string]inte
 		ch, _ := message["channel"].(string)
 
 		if errMsg := f.programErrors[program]; errMsg != "" {
-			textMsgs <- fmt.Sprintf(`{"type": "error", "message": "%s"}`, errMsg)
+			textMsgs <- fmt.Sprintf(`{"type": "error", "message": "%s", "channel": "%s"}`, errMsg, ch)
 		}
 
 		programTSIDs := f.tsidsByProgram[program]


### PR DESCRIPTION
Currently, a program error added by the client via `AddProgramError(program, errormsg)` does not come back from the fake_backend because it does not have a channel. 