### PR TITLE
signalflow: Fix channel end/abort control message handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           go get golang.org/x/tools/cmd/goimports
 
           go generate ./...
-          go test ./... -parallel 4
+          go test ./... -parallel 4 -timeout 2m
 workflows:
   version: 2
   build:
@@ -32,3 +32,6 @@ workflows:
       - test:
           name: "Go 1.14"
           go_version: "1.14"
+      - test:
+          name: "Go 1.15"
+          go_version: "1.15"

--- a/signalflow/computation.go
+++ b/signalflow/computation.go
@@ -240,14 +240,12 @@ func (c *Computation) processMessage(m messages.Message) {
 	defer c.updateSignal.SignalAll()
 	c.updateSignal.Lock()
 	defer c.updateSignal.Unlock()
+
 	switch v := m.(type) {
 	case *messages.JobStartControlMessage:
 		c.handle = v.Handle
-	case *messages.BaseControlMessage:
-		switch v.Event {
-		case messages.ChannelAbortEvent, messages.EndOfChannelEvent:
-			c.cancel()
-		}
+	case *messages.EndOfChannelControlMessage, *messages.ChannelAbortControlMessage:
+		c.cancel()
 	case *messages.DataMessage:
 		c.dataChBuffer <- v
 	case *messages.ExpiredTSIDMessage:

--- a/signalflow/messages/control.go
+++ b/signalflow/messages/control.go
@@ -20,3 +20,11 @@ type JobStartControlMessage struct {
 	BaseControlMessage
 	Handle string `json:"handle"`
 }
+
+type EndOfChannelControlMessage struct {
+	BaseControlMessage
+}
+
+type ChannelAbortControlMessage struct {
+	BaseControlMessage
+}

--- a/signalflow/messages/json.go
+++ b/signalflow/messages/json.go
@@ -18,6 +18,10 @@ func parseJSONMessage(baseMessage Message, msg []byte) (JSONMessage, error) {
 		switch base.Event {
 		case JobStartEvent:
 			out = &JobStartControlMessage{}
+		case EndOfChannelEvent:
+			out = &EndOfChannelControlMessage{}
+		case ChannelAbortEvent:
+			out = &ChannelAbortControlMessage{}
 		default:
 			return &base, nil
 		}

--- a/signalflow/messages/types_test.go
+++ b/signalflow/messages/types_test.go
@@ -1,0 +1,19 @@
+package messages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMessage(t *testing.T) {
+	t.Run("END_OF_CHANNEL", func(t *testing.T) {
+		msg, err := ParseMessage([]byte(`
+			{"channel": "ch-1", "event": "END_OF_CHANNEL", "timestampMs": 1607115512410, "type": "control-message"}
+		`), true)
+
+		require.NoError(t, err)
+		require.IsType(t, &EndOfChannelControlMessage{}, msg)
+	})
+
+}


### PR DESCRIPTION
A previous fix didn't seem to be working in all cases so this should
resolve it fully.