### PR TITLE
GET PagerDuty Integration By Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Improvements
 * Added `hideMissingValues` to chart.Options to show or hide missing values in the chart. [#111](https://github.com/signalfx/signalfx-go/pull/111)
 * Added `minDelay` field to detector.
+* Added `PagerDutyIntegrationGetByName` method.
 
 # 1.7.10, 2020-08-06
 * Don't omit chart.description from JSON, as API doesn't clear it if absent. [#107](https://github.com/signalfx/signalfx-go/pull/107)

--- a/integration/model_pager_duty_integration.go
+++ b/integration/model_pager_duty_integration.go
@@ -29,3 +29,10 @@ type PagerDutyIntegration struct {
 	// A key you get from PagerDuty that lets you integrate SignalFx with PagerDuty. PagerDuty refers to this property as the `integrationKey`. <br> **NOTE:** To ensure security, SignalFx doesn't return this property in response objects.
 	ApiKey string `json:"apiKey,omitempty"`
 }
+
+type PagerDutyIntegrationList struct {
+	// Number of integrations in the result set
+	Count int `json:"count,omitempty"`
+	// List of returned integration objects
+	Results []PagerDutyIntegration `json:"results,omitempty"`
+}

--- a/pagerduty_integration.go
+++ b/pagerduty_integration.go
@@ -63,6 +63,39 @@ func (c *Client) GetPagerDutyIntegration(ctx context.Context, id string) (*integ
 	return &finalIntegration, err
 }
 
+// GetPagerDutyIntegrationByName retrieves a PagerDuty integration by name.
+func (c *Client) GetPagerDutyIntegrationByName(ctx context.Context, name string) (*integration.PagerDutyIntegration, error) {
+	resp, err := c.doRequest(ctx, "GET", IntegrationAPIURL+"?type=PagerDuty&name="+name, nil, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		message, _ := ioutil.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Unexpected status code: %d: %s", resp.StatusCode, message)
+	}
+
+	integrationList := integration.PagerDutyIntegrationList{}
+
+	err = json.NewDecoder(resp.Body).Decode(&integrationList)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
+
+	if integrationList.Count == 0 {
+		return nil, nil
+	}
+
+	for _, integration := range integrationList.Results {
+		if integration.Name == name {
+			return &integration, nil
+		}
+	}
+
+	return nil, err
+}
+
 // UpdatePagerDutyIntegration updates a PagerDuty integration.
 func (c *Client) UpdatePagerDutyIntegration(ctx context.Context, id string, pdi *integration.PagerDutyIntegration) (*integration.PagerDutyIntegration, error) {
 	payload, err := json.Marshal(pdi)


### PR DESCRIPTION
I'm adding this because I would like to use it in the Terraform Provider to have a data source to pull Integration https://github.com/splunk-terraform/terraform-provider-signalfx/pull/274