### PR TITLE
Do not panic on null error message

### DIFF
--- a/signalflow/computation.go
+++ b/signalflow/computation.go
@@ -273,7 +273,7 @@ func (c *Computation) processMessage(m messages.Message) {
 		if code, ok := rawData["error"]; ok {
 			computationError.Code = int(code.(float64))
 		}
-		if msg, ok := rawData["message"]; ok {
+		if msg, ok := rawData["message"]; ok && msg != nil {
 			computationError.Message = msg.(string)
 		}
 		if errType, ok := rawData["errorType"]; ok {


### PR DESCRIPTION
In some circumstances, the [signalflow stream server](https://dev.splunk.com/observability/docs/signalflow/messages/stream_messages_specification/) can return error messages with a null `message` value

```json
{
  "type": "error",
  "error": 400,
  "errorType": "ANALYTICS_INTERNAL_ERROR",
  "message": null
}
```

signalfx-go will panic in this circumstance because it attempts to cast `message`, if present, to string. A nil check on the `message` value avoids the panic.