### PR TITLE
Return events/alerts from signalflow events/alerts queries

### DIFF
--- a/signalflow/computation.go
+++ b/signalflow/computation.go
@@ -35,6 +35,7 @@ type Computation struct {
 	groupByMissingProperties []string
 
 	tsidMetadata map[idtool.ID]*messages.MetadataProperties
+	events       []*messages.EventMessage
 
 	handle string
 
@@ -283,6 +284,8 @@ func (c *Computation) processMessage(m messages.Message) {
 		c.cancel()
 	case *messages.MetadataMessage:
 		c.tsidMetadata[v.TSID] = &v.Properties
+	case *messages.EventMessage:
+		c.events = append(c.events, v)
 	}
 }
 
@@ -350,6 +353,11 @@ func (c *Computation) bufferExpirationMessages() {
 // Data returns the channel on which data messages come.
 func (c *Computation) Data() <-chan *messages.DataMessage {
 	return c.dataCh
+}
+
+// Events returns the results from events or alerts queries
+func (c *Computation) Events() []*messages.EventMessage {
+	return c.events
 }
 
 // Expirations returns a channel that will be sent messages about expired

--- a/signalflow/computation.go
+++ b/signalflow/computation.go
@@ -210,6 +210,16 @@ func (c *Computation) TSIDMetadata(tsid idtool.ID) *messages.MetadataProperties 
 	return c.tsidMetadata[tsid]
 }
 
+// Events returns the results from events or alerts queries.
+func (c *Computation) Events() []*messages.EventMessage {
+	if err := c.waitForMetadata(func() bool { return c.events != nil }); err != nil {
+		return nil
+	}
+	c.updateSignal.Lock()
+	defer c.updateSignal.Unlock()
+	return c.events
+}
+
 // Done passes through the computation context's Done channel for use in select
 // statements to know when the computation is finished or an error occurred.
 func (c *Computation) Done() <-chan struct{} {
@@ -353,11 +363,6 @@ func (c *Computation) bufferExpirationMessages() {
 // Data returns the channel on which data messages come.
 func (c *Computation) Data() <-chan *messages.DataMessage {
 	return c.dataCh
-}
-
-// Events returns the results from events or alerts queries
-func (c *Computation) Events() []*messages.EventMessage {
-	return c.events
 }
 
 // Expirations returns a channel that will be sent messages about expired


### PR DESCRIPTION
Support running signal flow queries like:
```
D = alerts(detector_name='Deployment').publish(label='D')
F = events(eventType='deployment').publish(label='F')
```