### PR TITLE
Fix PagerDuty Integration query

### DIFF
--- a/pagerduty_integration.go
+++ b/pagerduty_integration.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 
 	"github.com/signalfx/signalfx-go/integration"
 )
@@ -65,7 +66,11 @@ func (c *Client) GetPagerDutyIntegration(ctx context.Context, id string) (*integ
 
 // GetPagerDutyIntegrationByName retrieves a PagerDuty integration by name.
 func (c *Client) GetPagerDutyIntegrationByName(ctx context.Context, name string) (*integration.PagerDutyIntegration, error) {
-	resp, err := c.doRequest(ctx, "GET", IntegrationAPIURL+"?type=PagerDuty&name="+name, nil, nil)
+	params := url.Values{}
+	params.Add("type", "PagerDuty")
+	params.Add("name", name)
+
+	resp, err := c.doRequest(ctx, "GET", IntegrationAPIURL, params, nil)
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/pagerduty_integration_test.go
+++ b/pagerduty_integration_test.go
@@ -33,6 +33,17 @@ func TestGetPagerDutyIntegration(t *testing.T) {
 	assert.Equal(t, "string", result.Name, "Name does not match")
 }
 
+func TestGetPagerDutyIntegrationByName(t *testing.T) {
+	teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/integration", verifyRequest(t, "GET", true, http.StatusOK, nil, "integration/get_by_name_pd_success.json"))
+
+	result, err := client.GetPagerDutyIntegrationByName(context.Background(), "string")
+	assert.NoError(t, err, "Unexpected error getting integration")
+	assert.Equal(t, "string", result.Name)
+}
+
 func TestUpdatePagerDutyIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()

--- a/testdata/fixtures/integration/get_by_name_pd_success.json
+++ b/testdata/fixtures/integration/get_by_name_pd_success.json
@@ -1,0 +1,11 @@
+{
+  "count": 1,
+  "results": [
+    {
+      "id": "string",
+      "name": "string",
+      "type": "PagerDuty",
+      "enabled": true
+    }
+  ]
+}


### PR DESCRIPTION
Signed-off-by: Salvatore Mazzarino <smazzarino@sessionm.com>

Fixing an issue in the URL parsing. `?` could not be parsed correctly. This have as result to not found the integration when the client is used for instance in Terraform provider