### PR TITLE
organizationId is needed in sessiontokenrequest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jherbage-splunk/signalfx-go
+module github.com/signalfx-go/signalfx-go
 
 go 1.12
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/signalfx-go/signalfx-go
+module github.com/signalfx/signalfx-go
 
 go 1.12
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/signalfx/signalfx-go
+module github.com/jherbage-splunk/signalfx-go
 
 go 1.12
 

--- a/sessiontoken/model_create_token_request.go
+++ b/sessiontoken/model_create_token_request.go
@@ -6,4 +6,6 @@ type CreateTokenRequest struct {
 	Email string `json:"email"`
 	// The password you provided to SignalFx when you accepted an invitation to join an organization. Only used for Create Token requests
 	Password string `json:"password"`
+	// Org to use - needed when the user uses same email in multiple orgs
+	OrganizationId string `json:"organizationId"`
 }


### PR DESCRIPTION
Without the ability to specify the organizationId in the session token request if the user has accounts in multiple orgs then you cannot control the oragnization id that the token is issued for
Note that the organizationId is also missing from the API spec:
https://dev.splunk.com/observability/reference/api/sessiontokens/latest#endpoint-create-session-token
but definitely exists as we use it in other repos that use curl rather than the go client