### PR TITLE
Fix for search Muting (name is not in api, query is)

### DIFF
--- a/alertmuting.go
+++ b/alertmuting.go
@@ -116,11 +116,11 @@ func (c *Client) UpdateAlertMutingRule(ctx context.Context, id string, muteReque
 }
 
 // SearchAlertMutingRules searches for alert muting rules given a query string in `name`.
-func (c *Client) SearchAlertMutingRules(ctx context.Context, include string, limit int, name string, offset int) (*alertmuting.SearchResult, error) {
+func (c *Client) SearchAlertMutingRules(ctx context.Context, include string, limit int, query string, offset int) (*alertmuting.SearchResult, error) {
 	params := url.Values{}
 	params.Add("include", include)
 	params.Add("limit", strconv.Itoa(limit))
-	params.Add("name", name)
+	params.Add("query", query)
 	params.Add("offset", strconv.Itoa(offset))
 
 	resp, err := c.doRequest(ctx, "GET", AlertMutingRuleAPIURL, params, nil)

--- a/alertmuting_test.go
+++ b/alertmuting_test.go
@@ -85,17 +85,17 @@ func TestSearchAlertMutingRule(t *testing.T) {
 
 	include := "all"
 	limit := 10
-	name := "foo"
+	query := "creator:AAXYAAAAAZ3"
 	offset := 2
 	params := url.Values{}
 	params.Add("include", include)
 	params.Add("limit", strconv.Itoa(limit))
-	params.Add("name", name)
+	params.Add("query", query)
 	params.Add("offset", strconv.Itoa(offset))
 
 	mux.HandleFunc("/v2/alertmuting", verifyRequest(t, "GET", true, http.StatusOK, params, "alertmuting/search_success.json"))
 
-	results, err := client.SearchAlertMutingRules(context.Background(), include, limit, name, offset)
+	results, err := client.SearchAlertMutingRules(context.Background(), include, limit, query, offset)
 	assert.NoError(t, err, "Unexpected error search alert muting rule")
 	assert.Equal(t, int32(1), results.Count, "Incorrect number of results")
 }


### PR DESCRIPTION
As per [api documentation](https://dev.splunk.com/observability/reference/api/incidents/latest#endpoint-retrieve-muting-rules-using-query).