### PR TITLE
Don't send empty orderBy query param and correct metrics search results field

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -62,7 +62,11 @@ func verifyRequest(t *testing.T, method string, expectToken bool, status int, pa
 		if params != nil {
 			incomingParams := r.URL.Query()
 			for k := range params {
+				assert.Contains(t, incomingParams, k, "Request is missing expected query parameter %q", k)
 				assert.Equal(t, params.Get(k), incomingParams.Get(k), "Params do match for parameter '"+k+"': '"+incomingParams.Get(k)+"'")
+			}
+			for k := range incomingParams {
+				assert.Contains(t, params, k, "Request contains unexpected query parameter %q", k)
 			}
 		}
 

--- a/metrics_metadata.go
+++ b/metrics_metadata.go
@@ -111,7 +111,9 @@ func (c *Client) SearchDimension(ctx context.Context, query string, orderBy stri
 func (c *Client) SearchMetric(ctx context.Context, query string, orderBy string, limit int, offset int) (*metrics_metadata.RetrieveMetricMetadataResponseModel, error) {
 	params := url.Values{}
 	params.Add("query", query)
-	params.Add("orderBy", orderBy)
+	if orderBy != "" {
+		params.Add("orderBy", orderBy)
+	}
 	params.Add("limit", strconv.Itoa(limit))
 	params.Add("offset", strconv.Itoa(offset))
 
@@ -186,7 +188,9 @@ func (c *Client) GetMetricTimeSeries(ctx context.Context, id string) (*metrics_m
 func (c *Client) SearchMetricTimeSeries(ctx context.Context, query string, orderBy string, limit int, offset int) (*metrics_metadata.MetricTimeSeriesRetrieveResponseModel, error) {
 	params := url.Values{}
 	params.Add("query", query)
-	params.Add("orderBy", orderBy)
+	if orderBy != "" {
+		params.Add("orderBy", orderBy)
+	}
 	params.Add("limit", strconv.Itoa(limit))
 	params.Add("offset", strconv.Itoa(offset))
 
@@ -215,7 +219,9 @@ func (c *Client) SearchMetricTimeSeries(ctx context.Context, query string, order
 func (c *Client) SearchTag(ctx context.Context, query string, orderBy string, limit int, offset int) (*metrics_metadata.TagRetrieveResponseModel, error) {
 	params := url.Values{}
 	params.Add("query", query)
-	params.Add("orderBy", orderBy)
+	if orderBy != "" {
+		params.Add("orderBy", orderBy)
+	}
 	params.Add("limit", strconv.Itoa(limit))
 	params.Add("offset", strconv.Itoa(offset))
 

--- a/metrics_metadata/model_retrieve_metric_metadata_response_model.go
+++ b/metrics_metadata/model_retrieve_metric_metadata_response_model.go
@@ -12,7 +12,7 @@ package metrics_metadata
 // The results of the metrics metadata request
 type RetrieveMetricMetadataResponseModel struct {
 	// An array of metrics metadata results
-	Result []*Metric `json:"result,omitempty"`
+	Results []*Metric `json:"results,omitempty"`
 	// Number of result objects returned. This value is the same as the size of the `result` value array.
 	Count int32 `json:"count,omitempty"`
 }

--- a/metrics_metadata_test.go
+++ b/metrics_metadata_test.go
@@ -52,7 +52,8 @@ func TestSearchDimension(t *testing.T) {
 
 	results, err := client.SearchDimension(context.Background(), query, orderBy, limit, offset)
 	assert.NoError(t, err, "Unexpected error search dimensions")
-	assert.Equal(t, int32(1), results.Count, "Incorrect number of results")
+	assert.Equal(t, int32(1), results.Count, "Incorrect results count")
+	assert.Equal(t, 1, len(results.Results), "Incorrect number of results")
 }
 
 func TestSearchDimensionBad(t *testing.T) {
@@ -72,7 +73,7 @@ func TestSearchDimensionBad(t *testing.T) {
 	mux.HandleFunc("/v2/dimension", verifyRequest(t, "GET", true, http.StatusBadRequest, params, ""))
 
 	_, err := client.SearchDimension(context.Background(), query, orderBy, limit, offset)
-	assert.Error(t, err, "Unexpected error search dimensions")
+	assert.Error(t, err, "Didn't receive expected error for search dimensions")
 }
 
 func TestUpdateDimension(t *testing.T) {
@@ -141,7 +142,8 @@ func TestSearchMetric(t *testing.T) {
 
 	results, err := client.SearchMetric(context.Background(), query, orderBy, limit, offset)
 	assert.NoError(t, err, "Unexpected error search metrics")
-	assert.Equal(t, int32(1), results.Count, "Incorrect number of results")
+	assert.Equal(t, int32(1), results.Count, "Incorrect results count")
+	assert.Equal(t, 1, len(results.Results), "Incorrect number of results")
 }
 
 func TestSearchMetricBad(t *testing.T) {
@@ -204,7 +206,8 @@ func TestSearchMetricTimeSeries(t *testing.T) {
 
 	results, err := client.SearchMetricTimeSeries(context.Background(), query, orderBy, limit, offset)
 	assert.NoError(t, err, "Unexpected error search metric time series")
-	assert.Equal(t, int32(1), results.Count, "Incorrect number of results")
+	assert.Equal(t, int32(1), results.Count, "Incorrect results count")
+	assert.Equal(t, 1, len(results.Results), "Incorrect number of results")
 }
 
 func TestSearchMetricTimeSeriesBad(t *testing.T) {
@@ -245,7 +248,8 @@ func TestSearchTag(t *testing.T) {
 
 	results, err := client.SearchTag(context.Background(), query, orderBy, limit, offset)
 	assert.NoError(t, err, "Unexpected error search tags")
-	assert.Equal(t, int32(1), results.Count, "Incorrect number of results")
+	assert.Equal(t, int32(1), results.Count, "Incorrect results count")
+	assert.Equal(t, 1, len(results.Results), "Incorrect number of results")
 }
 
 func TestSearchTagBad(t *testing.T) {

--- a/metrics_metadata_test.go
+++ b/metrics_metadata_test.go
@@ -41,6 +41,26 @@ func TestSearchDimension(t *testing.T) {
 	query := "foo:*"
 	limit := 10
 	offset := 2
+	params := url.Values{}
+	params.Add("query", query)
+	params.Add("limit", strconv.Itoa(limit))
+	params.Add("offset", strconv.Itoa(offset))
+
+	mux.HandleFunc("/v2/dimension", verifyRequest(t, "GET", true, http.StatusOK, params, "metrics_metadata/dimension_search_success.json"))
+
+	results, err := client.SearchDimension(context.Background(), query, "", limit, offset)
+	assert.NoError(t, err, "Unexpected error search dimensions")
+	assert.Equal(t, int32(1), results.Count, "Incorrect results count")
+	assert.Equal(t, 1, len(results.Results), "Incorrect number of results")
+}
+
+func TestSearchDimensionWithOrderBy(t *testing.T) {
+	teardown := setup()
+	defer teardown()
+
+	query := "foo:*"
+	limit := 10
+	offset := 2
 	orderBy := "bar"
 	params := url.Values{}
 	params.Add("orderBy", orderBy)
@@ -131,6 +151,26 @@ func TestSearchMetric(t *testing.T) {
 	query := "foo:*"
 	limit := 10
 	offset := 2
+	params := url.Values{}
+	params.Add("query", query)
+	params.Add("limit", strconv.Itoa(limit))
+	params.Add("offset", strconv.Itoa(offset))
+
+	mux.HandleFunc("/v2/metric", verifyRequest(t, "GET", true, http.StatusOK, params, "metrics_metadata/metric_search_success.json"))
+
+	results, err := client.SearchMetric(context.Background(), query, "", limit, offset)
+	assert.NoError(t, err, "Unexpected error search metrics")
+	assert.Equal(t, int32(1), results.Count, "Incorrect results count")
+	assert.Equal(t, 1, len(results.Results), "Incorrect number of results")
+}
+
+func TestSearchMetricWithOrderBy(t *testing.T) {
+	teardown := setup()
+	defer teardown()
+
+	query := "foo:*"
+	limit := 10
+	offset := 2
 	orderBy := "bar"
 	params := url.Values{}
 	params.Add("orderBy", orderBy)
@@ -195,6 +235,26 @@ func TestSearchMetricTimeSeries(t *testing.T) {
 	query := "foo:*"
 	limit := 10
 	offset := 2
+	params := url.Values{}
+	params.Add("query", query)
+	params.Add("limit", strconv.Itoa(limit))
+	params.Add("offset", strconv.Itoa(offset))
+
+	mux.HandleFunc("/v2/metrictimeseries", verifyRequest(t, "GET", true, http.StatusOK, params, "metrics_metadata/metric_time_series_search_success.json"))
+
+	results, err := client.SearchMetricTimeSeries(context.Background(), query, "", limit, offset)
+	assert.NoError(t, err, "Unexpected error search metric time series")
+	assert.Equal(t, int32(1), results.Count, "Incorrect results count")
+	assert.Equal(t, 1, len(results.Results), "Incorrect number of results")
+}
+
+func TestSearchMetricTimeSeriesWithOrderBy(t *testing.T) {
+	teardown := setup()
+	defer teardown()
+
+	query := "foo:*"
+	limit := 10
+	offset := 2
 	orderBy := "bar"
 	params := url.Values{}
 	params.Add("orderBy", orderBy)
@@ -231,6 +291,26 @@ func TestSearchMetricTimeSeriesBad(t *testing.T) {
 }
 
 func TestSearchTag(t *testing.T) {
+	teardown := setup()
+	defer teardown()
+
+	query := "foo:*"
+	limit := 10
+	offset := 2
+	params := url.Values{}
+	params.Add("query", query)
+	params.Add("limit", strconv.Itoa(limit))
+	params.Add("offset", strconv.Itoa(offset))
+
+	mux.HandleFunc("/v2/tag", verifyRequest(t, "GET", true, http.StatusOK, params, "metrics_metadata/tag_search_success.json"))
+
+	results, err := client.SearchTag(context.Background(), query, "", limit, offset)
+	assert.NoError(t, err, "Unexpected error search tags")
+	assert.Equal(t, int32(1), results.Count, "Incorrect results count")
+	assert.Equal(t, 1, len(results.Results), "Incorrect number of results")
+}
+
+func TestSearchTagWithOrderBy(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 

--- a/testdata/fixtures/metrics_metadata/metric_search_success.json
+++ b/testdata/fixtures/metrics_metadata/metric_search_success.json
@@ -1,6 +1,6 @@
 {
   "count": 1,
-  "result": [
+  "results": [
     {
       "created": 1556055030000,
       "creator": "string",


### PR DESCRIPTION
These changes prevent sending the `orderBy` query parameter in remaining search helpers if an empty string is provided (currently triggering an issue with the API).

They also correct what appears to be a typo on the `RetrieveMetricMetadataResponseModel` struct that occurred during the OpenAPI-based helper generation.  As far as I can tell this field has never been named "result" in the product.  This includes a potential breaking change by updating the `Result` field name to `Results` to match the other models and response.  I opted for this change to meet the signatures of the other result models and since it's not been functional I'm not sure how breaking it can actually be considered.