### PR TITLE
Context cancellation handling

### DIFF
--- a/signalflow/conn.go
+++ b/signalflow/conn.go
@@ -77,8 +77,7 @@ func (c *wsConn) Run() {
 
 	for {
 		if conn == nil {
-			select {
-			case <-c.ctx.Done():
+			if c.ctx.Err() == context.Canceled {
 				log.Printf("Context cancelled, stop reconnecting.")
 				return
 			}

--- a/signalflow/conn.go
+++ b/signalflow/conn.go
@@ -77,14 +77,14 @@ func (c *wsConn) Run() {
 
 	for {
 		if conn == nil {
-			if c.ctx.Err() == context.Canceled {
-				log.Printf("Context cancelled, stop reconnecting.")
-				return
-			}
-
 			// This will get run on before the first connection as well.
 			if c.PostDisconnectCallback != nil {
 				c.PostDisconnectCallback()
+			}
+
+			if c.ctx.Err() == context.Canceled {
+				log.Printf("Context cancelled, stop reconnecting.")
+				return
 			}
 
 			var err error

--- a/signalflow/conn.go
+++ b/signalflow/conn.go
@@ -77,6 +77,12 @@ func (c *wsConn) Run() {
 
 	for {
 		if conn == nil {
+			select {
+			case <-c.ctx.Done():
+				log.Printf("Context cancelled, stop reconnecting.")
+				return
+			}
+
 			// This will get run on before the first connection as well.
 			if c.PostDisconnectCallback != nil {
 				c.PostDisconnectCallback()


### PR DESCRIPTION
According to [documentation](https://github.com/signalfx/signalfx-go/blob/6c74a9c6a4a52df5808c02a89da8bb7f0a8ce5cf/signalflow/client.go#L325-L326) after `Client.Close()` is invoked, client should not be used anymore. This behavior is desired.
> Close the client and shutdown any ongoing connections and go routines.  The client cannot be reused after Close.

The problem is when connection is not ready and `Client.Close()` is invoked, context is canceled but reconnect tries[ indefinitely connect to the server without checking context](https://github.com/signalfx/signalfx-go/blob/6c74a9c6a4a52df5808c02a89da8bb7f0a8ce5cf/signalflow/conn.go#L78-L103) status. There is no way to stop go routine.

**Steps to reproduce:**
1. Create client with invalid realm.
2. Close connection with `client.Close()`.
```go
client, err = signalflow.NewClient(
  signalflow.StreamURLForRealm("foo"),
  signalflow.AccessToken(s.AccessToken),
)
client.Close()
```

**Expected result:**
1. Context is cancelled, reconnecting stopped.
2. Go routine is closed when context is canceled.

**Actual result:**
1. Context is cancelled and go routine is running in the background indefinitely. Log printed every 5 seconds with message `Error connecting to SignalFlow websocket: could not connect Signalflow websocket: dial tcp: operation was canceled`
2. There is now way to close this go routine outside the Client. 