### PR TITLE
fix robomaker and medialive namespaces

### DIFF
--- a/integration/model_aws_service.go
+++ b/integration/model_aws_service.go
@@ -181,6 +181,6 @@ var AWSServiceNames = map[string]AwsService{
 	"AWS/WorkMail":                AWSWORK_MAIL,
 	"AWS/WorkSpaces":              AWSWORK_SPACES,
 	"AWS/Neptune":                 AWSNEPTUNE,
-	"MediaLive":               AWSMEDIA_LIVE,
+	"MediaLive":                   AWSMEDIA_LIVE,
 	"System/Linux":                AWS_SYSTEM_LINUX,
 }

--- a/integration/model_aws_service.go
+++ b/integration/model_aws_service.go
@@ -70,7 +70,7 @@ const (
 	AWSPOLLY                     AwsService = "AWS/Polly"
 	AWSREDSHIFT                  AwsService = "AWS/Redshift"
 	AWSRDS                       AwsService = "AWS/RDS"
-	AWSROBOMAKER                 AwsService = "AWS/RoboMaker"
+	AWSROBOMAKER                 AwsService = "AWS/Robomaker"
 	AWSROUTE53                   AwsService = "AWS/Route53"
 	AWSSAGE_MAKER                AwsService = "AWS/SageMaker"
 	AWSSAGE_MAKER_TRAINING_JOBS  AwsService = "aws/sagemaker/TrainingJobs"
@@ -95,7 +95,7 @@ const (
 	AWSWORK_MAIL                 AwsService = "AWS/WorkMail"
 	AWSWORK_SPACES               AwsService = "AWS/WorkSpaces"
 	AWSNEPTUNE                   AwsService = "AWS/Neptune"
-	AWSMEDIA_LIVE                AwsService = "AWS/MediaLive"
+	AWSMEDIA_LIVE                AwsService = "MediaLive"
 	AWS_SYSTEM_LINUX             AwsService = "System/Linux"
 )
 
@@ -156,7 +156,7 @@ var AWSServiceNames = map[string]AwsService{
 	"AWS/Polly":                   AWSPOLLY,
 	"AWS/Redshift":                AWSREDSHIFT,
 	"AWS/RDS":                     AWSRDS,
-	"AWS/RoboMaker":               AWSROBOMAKER,
+	"AWS/Robomaker":               AWSROBOMAKER,
 	"AWS/Route53":                 AWSROUTE53,
 	"AWS/SageMaker":               AWSSAGE_MAKER,
 	"aws/sagemaker/TrainingJobs":  AWSSAGE_MAKER_TRAINING_JOBS,
@@ -181,6 +181,6 @@ var AWSServiceNames = map[string]AwsService{
 	"AWS/WorkMail":                AWSWORK_MAIL,
 	"AWS/WorkSpaces":              AWSWORK_SPACES,
 	"AWS/Neptune":                 AWSNEPTUNE,
-	"AWS/MediaLive":               AWSMEDIA_LIVE,
+	"MediaLive":               AWSMEDIA_LIVE,
 	"System/Linux":                AWS_SYSTEM_LINUX,
 }


### PR DESCRIPTION
related to https://github.com/splunk-terraform/terraform-provider-signalfx/pull/314 and https://github.com/signalfx/signalfx-go/pull/132 and support ticket 00019838

@dloucasfx @jrcamp @asuresh4 @keitwb

I found the https://app.eu0.signalfx.com/v2/aws/supportedNamespacesAndRegions (undocumented I think). while it requires a token it seems not possible to build the model fully dynamically.

Nevertheless, the manual update of aws and azure services is painful and always done after a customer feedback which is not really a proactive approach.

To clean manually this time I run the following script:

```bash
#!/bin/bash

if ! [ -v SFX_TOKEN ]; then
    echo "You must set environment variable \"SFX_TOKEN\""
    exit 1
fi

ERR=0
MODEL_FILE="integration/model_aws_service.go"
API_URL="https://app.${SFX_REALM:-us0}.signalfx.com/v2/aws/supportedNamespacesAndRegions"

resp=$(curl --fail-with-body -s "${API_URL}" -H "X-SF-TOKEN: ${SFX_TOKEN}")
if [ $? -ne 0 ]; then
    echo "Error during api call to ${API_URL}:"
    echo "$resp"
    exit -1
fi
supported_services=$(echo "$resp" | jq -rc '.namespaces | keys | .[]')

for namespace in $(echo "$supported_services"); do
    if ! grep -q "AwsService = \"$namespace\"" ${MODEL_FILE}; then
        echo "Missing namespace $namespace from $MODEL_FILE"
        ((ERR++))
    fi
done

echo "$supported_services" > /tmp/aws_services.txt
for namespace in $(grep AwsService.*= $MODEL_FILE | sed 's/^.*AwsService[[:space:]]=[[:space:]]"\(.*\)"/\1/g'); do
    if ! grep -q "^${namespace}$" <<<$supported_services; then
        echo "Undesired namespace $namespace should not be in $MODEL_FILE"
    fi
done

exit $ERR

```

the output before this change:

```bash
Missing namespace AWS/Robomaker from integration/model_aws_service.go
Missing namespace MediaLive from integration/model_aws_service.go
Undesired namespace AWS/RoboMaker should not be in integration/model_aws_service.go
Undesired namespace AWS/MediaLive should not be in integration/model_aws_service.go
```