### PR TITLE
Adding AuthScopes attribute to the org token struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 coverage.out
 coverage.html
+.idea

--- a/orgtoken/model_create_update_token_request.go
+++ b/orgtoken/model_create_update_token_request.go
@@ -17,6 +17,8 @@ import (
 type CreateUpdateTokenRequest struct {
 	// A label ( a **name** ) you assign to the token
 	Name string `json:"name"`
+	// Specify the scope this token applies to ex: API, INGEST, RUM etc...
+	AuthScopes []string `json:"authScopes,omitempty"`
 	// An extended description of the token
 	Description string `json:"description,omitempty"`
 	// Specifies org token limits and thresholds. Use the form that corresponds to your pricing model: <br>   * For DPM pricing, use \"dpmQuota\"   * For host-based pricing, use \"categoryQuota\"<br>   You can only set limits if you have an Enterprise-level account.

--- a/orgtoken/model_token.go
+++ b/orgtoken/model_token.go
@@ -17,6 +17,8 @@ import (
 type Token struct {
 	// A label ( a **name** ) you assign to the token
 	Name string `json:"name"`
+	// Specify the scope this token applies to ex: API, INGEST, RUM etc...
+	AuthScopes []string `json:"authScopes,omitempty"`
 	// An extended description of the token
 	Description string `json:"description,omitempty"`
 	// Specifies org token limits and thresholds. Use the form that corresponds to your pricing model: <br>   * For DPM pricing, use \"dpmQuota\"   * For host-based pricing, use \"categoryQuota\"<br>   You can only set limits if you have an Enterprise-level account.


### PR DESCRIPTION
This repo used to auto-generate the structs from https://github.com/signalfx/api-reference but our api specs repo has been archived and dated, hence the manual update.

For this PR, we need to add `AuthScopes` to the org token struct as this field is required when making changes to an existing token that has `limits` defined.

I also added `.idea` to the gitignore file

Signed-off-by: Dani Louca <dlouca@splunk.com>