### PR TITLE
Add MetricStreamsSyncState to AWS Cloudwatch integration

### DIFF
--- a/aws_cloudwatch_integration_test.go
+++ b/aws_cloudwatch_integration_test.go
@@ -46,6 +46,21 @@ func TestUpdateAWSCloudWatchIntegration(t *testing.T) {
 	assert.Equal(t, "string", result.Name, "Name does not match")
 }
 
+func TestUpdateAWSCloudWatchIntegrationMetricStreams(t *testing.T) {
+	teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/integration/id", verifyRequest(t, "PUT", true, http.StatusOK, nil, "integration/create_aws_metric_streams_success.json"))
+
+	result, err := client.UpdateAWSCloudWatchIntegration(context.Background(), "id", &integration.AwsCloudWatchIntegration{
+		Type: "AWSCloudWatch",
+		MetricStreamsSyncState: "ENABLED",
+	})
+	assert.NoError(t, err, "Unexpected error creating integration")
+	assert.Equal(t, "string", result.Name, "Name does not match")
+	assert.Equal(t, "ENABLED", result.MetricStreamsSyncState, "MetricStreamsSyncState does not match")
+}
+
 func TestDeleteAWSCloudWatchIntegration(t *testing.T) {
 	teardown := setup()
 	defer teardown()

--- a/integration/model_aws_cloud_watch_integration.go
+++ b/integration/model_aws_cloud_watch_integration.go
@@ -58,5 +58,7 @@ type AwsCloudWatchIntegration struct {
 	IsLargeVolume bool `json:"isLargeVolume,omitempty"`
 	// If `true`, this property indicates that SignalFx should use the GetMetricData API.
 	UseGetMetricDataMethod bool   `json:"useGetMetricDataMethod,omitempty"`
+	// If `ENABLED`, this property indicates that SignalFx should use Cloudwatch Metric Streams.
+	MetricStreamsSyncState string `json:"metricStreamsSyncState,omitempty"`
 	NamedToken             string `json:"namedToken,omitempty"`
 }

--- a/testdata/fixtures/integration/create_aws_metric_streams_success.json
+++ b/testdata/fixtures/integration/create_aws_metric_streams_success.json
@@ -1,0 +1,50 @@
+{
+  "created": 1556361030000,
+  "creator": "string",
+  "enabled": true,
+  "id": "string",
+  "lastUpdated": 1556620230000,
+  "lastUpdatedBy": "string",
+  "name": "string",
+  "type": "AWSCloudWatch",
+  "authMethod": "ExternalId",
+  "customCloudWatchNamespaces": "string",
+  "customNamespaceSyncRules": [
+    {
+      "defaultAction": "Exclude",
+      "filter": {
+        "action": "Exclude",
+        "source": "string"
+      },
+      "namespace": "string"
+    }
+  ],
+  "enableAwsUsage": true,
+  "enableCheckLargeVolume": true,
+  "externalId": "string",
+  "importCloudWatch": true,
+  "isLargeVolume": true,
+  "key": "string",
+  "namespaceSyncRules": [
+    {
+      "defaultAction": "Exclude",
+      "filter": {
+        "action": "Exclude",
+        "source": "string"
+      },
+      "namespace": "AWS/ApiGateway"
+    }
+  ],
+  "pollRate": 60000,
+  "regions": [
+    "ap-northeast-1"
+  ],
+  "roleArn": "string",
+  "services": [
+    "AWS/ApiGateway"
+  ],
+  "sfxAwsAccountArn": "arn:aws:iam::1234567890:root",
+  "token": "string",
+  "useGetMetricDataMethod": false,
+  "metricStreamsSyncState": "ENABLED"
+}


### PR DESCRIPTION
This PR adds support for setting `metricStreamsSyncState`

https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws-apiconfig.html#nav-Connect-to-AWS-using-the-Splunk-Observability-Cloud-API