### PR TITLE
signalflow: Fix race in computation buffering when closing

### DIFF
--- a/signalflow/computation.go
+++ b/signalflow/computation.go
@@ -306,6 +306,9 @@ func (c *Computation) bufferDataMessages() {
 	var nextMessage *messages.DataMessage
 
 	defer func() {
+		if nextMessage != nil {
+			c.dataCh <- nextMessage
+		}
 		for i := range buffer {
 			c.dataCh <- buffer[i]
 		}
@@ -350,6 +353,9 @@ func (c *Computation) bufferExpirationMessages() {
 	var nextMessage *messages.ExpiredTSIDMessage
 
 	defer func() {
+		if nextMessage != nil {
+			c.expirationCh <- nextMessage
+		}
 		for i := range buffer {
 			c.expirationCh <- buffer[i]
 		}


### PR DESCRIPTION


Previously the messages were not getting fully flushed to the downstream channels