### PR TITLE
Add PollRateMs to Azure and GCP integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
-# 2.0.0, 11 Mar 2022
+# 1.9.0, 11 Mar 2022
 
-* BREAKING CHANGE: use `int64` (value in milliseconds) instead of the `PollRate` type to define Azure and GCP integration poll rate [#153](https://github.com/signalfx/signalfx-go/pull/153)
+* Add support for read permissions for dashboard and dashboard groups
 
-Instead of the `integration.OneMinutely` use `60000`.<BR>
-Instead of the `integration.FiveMinutely` use `300000`.<BR>
-You may use any value between 1 and 10 minutes (`60000` - `600000`).
+* Add `AWS/S3/Storage-Lens` to AWS services list. Sorted AWS/Azure/GCP services by name. [#154](https://github.com/signalfx/signalfx-go/pull/154)
 
-* Added `AWS/S3/Storage-Lens` to AWS services list. Sorted AWS/Azure/GCP services by name. [#154](https://github.com/signalfx/signalfx-go/pull/154)
+* Add `PollRateMs` (type `int64`, value in milliseconds) to define Azure and GCP integration poll rate [#153](https://github.com/signalfx/signalfx-go/pull/153) [#155](https://github.com/signalfx/signalfx-go/pull/155)
+
+`PollRate` (type `PollRate`) is deprecated. Please use `PollRateMs` instead.<BR>
+`PollRateMs` accepts any value between 1 and 10 minutes (`60000` - `600000`).
 
 # 1.8.9, 3 Mar 2022
 

--- a/azure_integration_test.go
+++ b/azure_integration_test.go
@@ -20,7 +20,8 @@ func TestCreateAzureIntegration(t *testing.T) {
 	})
 	assert.NoError(t, err, "Unexpected error creating integration")
 	assert.Equal(t, "string", result.Name, "Name does not match")
-	assert.Equal(t, int64(120000), result.PollRate, "PollRate does not match")
+	assert.Nil(t, result.PollRate, "PollRate does not match")
+	assert.Equal(t, int64(120000), result.PollRateMs, "PollRateMs does not match")
 }
 
 func TestGetAzureIntegration(t *testing.T) {

--- a/gcp_integration_test.go
+++ b/gcp_integration_test.go
@@ -20,7 +20,8 @@ func TestCreateGCPIntegration(t *testing.T) {
 	})
 	assert.NoError(t, err, "Unexpected error creating integration")
 	assert.Equal(t, "string", result.Name, "Name does not match")
-	assert.Equal(t, int64(70000), result.PollRate, "PollRate does not match")
+	assert.Equal(t, integration.FiveMinutely, *result.PollRate, "PollRate does not match")
+	assert.Equal(t, int64(300000), result.PollRateMs, "PollRateMs does not match")
 }
 
 func TestGetGCPIntegration(t *testing.T) {

--- a/integration/model_azure_integration_test.go
+++ b/integration/model_azure_integration_test.go
@@ -1,0 +1,47 @@
+package integration
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarshalAzureIntegrationWithPollRate(t *testing.T) {
+	pollRate := OneMinutely
+	azureInt := AzureIntegration{
+		PollRate: &pollRate,
+	}
+	payload, err := json.Marshal(&azureInt)
+
+	assert.NoError(t, err, "Unexpected error marshalling integration")
+	assert.Equal(t, `{"enabled":false,"type":"","pollRate":60000,"syncGuestOsNamespaces":false}`, string(payload), "payload does not match")
+	assert.Equal(t, int64(0), azureInt.PollRateMs, "PollRateMs has been changed")
+}
+
+func TestMarshalAzureIntegrationWithPollRateMs(t *testing.T) {
+	payload, err := json.Marshal(AzureIntegration{
+		PollRateMs: 90000,
+	})
+
+	assert.NoError(t, err, "Unexpected error marshalling integration")
+	assert.Equal(t, `{"enabled":false,"type":"","pollRate":90000,"syncGuestOsNamespaces":false}`, string(payload), "payload does not match")
+}
+
+func TestUnmarshalAzureIntegrationWithPollRate(t *testing.T) {
+	azure := AzureIntegration{}
+	err := json.Unmarshal([]byte(`{"pollRate":60000}`), &azure)
+
+	assert.NoError(t, err, "Unexpected error unmarshalling integration")
+	assert.Equal(t, OneMinutely, *azure.PollRate, "PollRate does not match")
+	assert.Equal(t, int64(60000), azure.PollRateMs, "PollRateMs does not match")
+}
+
+func TestUnmarshalAzureIntegrationWithPollRateMs(t *testing.T) {
+	azure := AzureIntegration{}
+	err := json.Unmarshal([]byte(`{"pollRate":90000}`), &azure)
+
+	assert.NoError(t, err, "Unexpected error unmarshalling integration")
+	assert.Nil(t, azure.PollRate, "PollRate does not match")
+	assert.Equal(t, int64(90000), azure.PollRateMs, "PollRateMs does not match")
+}

--- a/integration/model_gcp_integration_test.go
+++ b/integration/model_gcp_integration_test.go
@@ -1,0 +1,47 @@
+package integration
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarshalGCPIntegrationWithPollRate(t *testing.T) {
+	pollRate := OneMinutely
+	gcpInt := GCPIntegration{
+		PollRate: &pollRate,
+	}
+	payload, err := json.Marshal(&gcpInt)
+
+	assert.NoError(t, err, "Unexpected error marshalling integration")
+	assert.Equal(t, `{"enabled":false,"type":"","pollRate":60000}`, string(payload), "payload does not match")
+	assert.Equal(t, int64(0), gcpInt.PollRateMs, "PollRateMs has been changed")
+}
+
+func TestMarshalGCPIntegrationWithPollRateMs(t *testing.T) {
+	payload, err := json.Marshal(GCPIntegration{
+		PollRateMs: 90000,
+	})
+
+	assert.NoError(t, err, "Unexpected error marshalling integration")
+	assert.Equal(t, `{"enabled":false,"type":"","pollRate":90000}`, string(payload), "payload does not match")
+}
+
+func TestUnmarshalGCPIntegrationWithPollRate(t *testing.T) {
+	GCP := GCPIntegration{}
+	err := json.Unmarshal([]byte(`{"pollRate":60000}`), &GCP)
+
+	assert.NoError(t, err, "Unexpected error unmarshalling integration")
+	assert.Equal(t, OneMinutely, *GCP.PollRate, "PollRate does not match")
+	assert.Equal(t, int64(60000), GCP.PollRateMs, "PollRateMs does not match")
+}
+
+func TestUnmarshalGCPIntegrationWithPollRateMs(t *testing.T) {
+	GCP := GCPIntegration{}
+	err := json.Unmarshal([]byte(`{"pollRate":90000}`), &GCP)
+
+	assert.NoError(t, err, "Unexpected error unmarshalling integration")
+	assert.Nil(t, GCP.PollRate, "PollRate does not match")
+	assert.Equal(t, int64(90000), GCP.PollRateMs, "PollRateMs does not match")
+}

--- a/testdata/fixtures/integration/create_gcp_success.json
+++ b/testdata/fixtures/integration/create_gcp_success.json
@@ -7,7 +7,7 @@
   "lastUpdatedBy": "string",
   "name": "string",
   "type": "GCP",
-  "pollRate": 70000,
+  "pollRate": 300000,
   "projectServiceKeys": [
     {
       "projectId": "string",


### PR DESCRIPTION
This is a backwards compatible solution that allows to use any poll rate value between 1 and 10 minutes without breaking existing code.

Side note: breaking changes in go land are highly discouraged, see:
https://research.swtch.com/vgo-import