### PR TITLE
Add includeList to GCP integration

### DIFF
--- a/integration/model_gcp_integration.go
+++ b/integration/model_gcp_integration.go
@@ -34,9 +34,10 @@ type GCPIntegration struct {
 	Services []GcpService `json:"services,omitempty"`
 	// List of GCP project that you want SignalFx to monitor, in the form of a JSON array of objects
 	ProjectServiceKeys []*GCPProject `json:"projectServiceKeys,omitempty"`
-	// List of GCP metadata names that you want SignalFx to collect from the data incoming from the GCP integration, in the form of a JSON array. Refer to Google's GCP documentation to find out the names you want to whitelist.
-	Whitelist  []string `json:"whitelist,omitempty"`
-	NamedToken string   `json:"namedToken,omitempty"`
+	// List of custom metadata keys that you want SignalFx to collect for Compute Engine Instances, in the form of a JSON array. Refer to Google's GCP documentation to find out the names you want to include.
+	IncludeList []string `json:"includeList,omitempty"`
+	Whitelist   []string `json:"-"`
+	NamedToken  string   `json:"namedToken,omitempty"`
 }
 
 func (gcp *GCPIntegration) MarshalJSON() ([]byte, error) {
@@ -44,6 +45,9 @@ func (gcp *GCPIntegration) MarshalJSON() ([]byte, error) {
 	var copy = Alias(*gcp)
 	if copy.PollRate != nil {
 		copy.PollRateMs = int64(*copy.PollRate)
+	}
+	if copy.IncludeList == nil && copy.Whitelist != nil {
+		copy.IncludeList = copy.Whitelist
 	}
 	return json.Marshal(&struct{ *Alias }{
 		Alias: &copy,
@@ -67,5 +71,9 @@ func (gcp *GCPIntegration) UnmarshalJSON(data []byte) error {
 		fiveMinutes := FiveMinutely
 		gcp.PollRate = &fiveMinutes
 	} // else PollRate is going to be nil
+
+	if gcp.IncludeList != nil {
+		gcp.Whitelist = gcp.IncludeList
+	}
 	return nil
 }

--- a/integration/model_gcp_integration_test.go
+++ b/integration/model_gcp_integration_test.go
@@ -45,3 +45,36 @@ func TestUnmarshalGCPIntegrationWithPollRateMs(t *testing.T) {
 	assert.Nil(t, GCP.PollRate, "PollRate does not match")
 	assert.Equal(t, int64(90000), GCP.PollRateMs, "PollRateMs does not match")
 }
+
+func TestMarshalGCPIntegrationWithWhitelist(t *testing.T) {
+	whitelist := []string{"key"}
+	gcpInt := GCPIntegration{
+		Whitelist: whitelist,
+	}
+	payload, err := json.Marshal(&gcpInt)
+
+	assert.NoError(t, err, "Unexpected error marshalling integration")
+	assert.Equal(t, `{"enabled":false,"type":"","includeList":["key"]}`, string(payload), "payload does not match")
+	assert.Nil(t, gcpInt.IncludeList, "IncludeList has been changed")
+}
+
+func TestMarshalGCPIntegrationWithIncludeList(t *testing.T) {
+	includeList := []string{"key"}
+	payload, err := json.Marshal(GCPIntegration{
+		IncludeList: includeList,
+	})
+
+	assert.NoError(t, err, "Unexpected error marshalling integration")
+	assert.Equal(t, `{"enabled":false,"type":"","includeList":["key"]}`, string(payload), "payload does not match")
+}
+
+func TestUnmarshalGCPIntegrationWithIncludeList(t *testing.T) {
+	expectedValue := []string{"key"}
+
+	GCP := GCPIntegration{}
+	err := json.Unmarshal([]byte(`{"includeList":["key"]}`), &GCP)
+
+	assert.NoError(t, err, "Unexpected error unmarshalling integration")
+	assert.Equal(t, expectedValue, GCP.IncludeList, "IncludeList does not match")
+	assert.Equal(t, expectedValue, GCP.Whitelist, "Whitelist does not match")
+}


### PR DESCRIPTION
Whitelist field is deprecated and will be replaced
with includeList field. This is a backward compatible
solution that replaces whitelist with includeList