### PR TITLE
New functions to retrieve incidents

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -1,0 +1,62 @@
+package signalfx
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/signalfx/signalfx-go/detector"
+)
+
+// IncidentAPIURL is the base URL for interacting with alert muting rules.
+const IncidentAPIURL = "/v2/incident"
+
+// Get incident with the given id
+func (c *Client) GetIncident(ctx context.Context, id string) (*detector.Incident, error) {
+	resp, err := c.doRequest(ctx, "GET", IncidentAPIURL+"/"+id, nil, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		message, _ := ioutil.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Bad status %d: %s", resp.StatusCode, message)
+	}
+
+	finalIncident := &detector.Incident{}
+
+	err = json.NewDecoder(resp.Body).Decode(finalIncident)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
+
+	return finalIncident, err
+}
+
+// Get all incidents
+func (c *Client) GetIncidents(ctx context.Context, includeResolved bool, limit int, query string, offset int) ([]*detector.Incident, error) {
+	params := url.Values{}
+	params.Add("includeResolved", strconv.FormatBool(includeResolved))
+	params.Add("limit", strconv.Itoa(limit))
+	params.Add("query", query)
+	params.Add("offset", strconv.Itoa(offset))
+	resp, err := c.doRequest(ctx, "GET", IncidentAPIURL, params, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var incidents []*detector.Incident
+	err = json.NewDecoder(resp.Body).Decode(&incidents)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
+
+	return incidents, err
+}

--- a/incident_test.go
+++ b/incident_test.go
@@ -1,0 +1,35 @@
+package signalfx
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetIncident(t *testing.T) {
+	teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/incident/string", verifyRequest(t, "GET", true, http.StatusOK, nil, "incident/get_incident.json"))
+
+	result, err := client.GetIncident(context.Background(), "string")
+	assert.NoError(t, err, "Unexpected error getting incident")
+	assert.Equal(t, result.IncidentId, "string", "Name does not match")
+	assert.Equal(t, true, result.Active, "Active field does not match")
+}
+
+func TestGetIncidents(t *testing.T) {
+	teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/incident", verifyRequest(t, "GET", true, http.StatusOK, nil, "incident/get_incidents.json"))
+
+	result, err := client.GetIncidents(context.Background(), false, 10, "", 0)
+	assert.NoError(t, err, "Unexpected error getting all incidents")
+	assert.Equal(t, len(result), 2, "Incorrect number of incidents returned")
+	assert.Equal(t, result[0].IncidentId, "string", "Name does not match")
+	assert.Equal(t, result[0].Active, true, "Active field does not match")
+	assert.Equal(t, result[1].IncidentId, "string1", "Name does not match")
+}

--- a/testdata/fixtures/incident/get_incident.json
+++ b/testdata/fixtures/incident/get_incident.json
@@ -1,0 +1,26 @@
+{
+  "active": true,
+  "anomalyState": "ANOMALOUS",
+  "detectLabel": "string",
+  "detectorId": "string",
+  "events": [
+    {
+      "anomalyState": "ANOMALOUS",
+      "detectLabel": "string",
+      "detectorId": "string",
+      "detectorName": "string",
+      "duration": 0,
+      "event_annotations": {},
+      "id": "string",
+      "incidentId": "string",
+      "inputs": {
+      "A": 5,
+      "B": 6
+      },
+      "severity": "Critical",
+      "timestamp": 1557484230000
+    }
+  ],
+  "incidentId": "string",
+  "severity": "Critical"
+}

--- a/testdata/fixtures/incident/get_incidents.json
+++ b/testdata/fixtures/incident/get_incidents.json
@@ -1,0 +1,55 @@
+[
+  {
+    "active": true,
+    "anomalyState": "ANOMALOUS",
+    "detectLabel": "string",
+    "detectorId": "string",
+    "events": [
+      {
+        "anomalyState": "ANOMALOUS",
+        "detectLabel": "string",
+        "detectorId": "string",
+        "detectorName": "string",
+        "duration": 0,
+        "event_annotations": {},
+        "id": "string",
+        "incidentId": "string",
+        "inputs": {
+        "A": 5,
+        "B": 6
+        },
+        "severity": "Critical",
+        "timestamp": 1557484230000
+      }
+    ],
+    "incidentId": "string",
+    "severity": "Critical"
+  },
+  {
+    "active": true,
+    "anomalyState": "ANOMALOUS",
+    "detectLabel": "string1",
+    "detectorId": "string1",
+    "events": [
+      {
+        "anomalyState": "ANOMALOUS",
+        "detectLabel": "string1",
+        "detectorId": "string1",
+        "detectorName": "string1",
+        "duration": 0,
+        "event_annotations": {},
+        "id": "string1",
+        "incidentId": "string1",
+        "inputs": {
+        "A": 5,
+        "B": 6
+        },
+        "severity": "Critical",
+        "timestamp": 1557484230000
+      }
+    ],
+    "incidentId": "string1",
+    "severity": "Critical"
+  }
+]
+  


### PR DESCRIPTION
Add two functions `GetIncident` and `GetIncidents` which retrieve incidents using the `/v2/incident/` api. Currently there is only support to get incidents based on detector ids.