### PR TITLE
Fix sendAlertsOnceMutingPeriodHasEnded JSON marshaling bug

### DIFF
--- a/alertmuting/model_alert_muting_rule.go
+++ b/alertmuting/model_alert_muting_rule.go
@@ -25,8 +25,8 @@ type AlertMutingRule struct {
 	LastUpdated int64 `json:"lastUpdated,omitempty"`
 	// The SignalFx-assigned user ID of the last user who updated the alert muting rule, in the form of a JSON string. If the system made the  last update, the value is \"AAAAAAAAAA\". **This property is read-only;  it's always set by the system.**
 	LastUpdatedBy string `json:"lastUpdatedBy,omitempty"`
-	// Toggle if alerts should be sent once the muting period is over.  If not specified, defaults to true
-	SendAlertsOnceMutingPeriodHasEnded bool `json:"sendAlertsOnceMutingPeriodHasEnded,omitempty"`
+	// Toggle if alerts should be sent once the muting period is over.  If not specified, defaults to false
+	SendAlertsOnceMutingPeriodHasEnded bool `json:"sendAlertsOnceMutingPeriodHasEnded"`
 	// Starting time of an alert muting rule, in Unix time format UTC. If not specified, defaults to the current time. **read/write**.
 	StartTime int64 `json:"startTime,omitempty"`
 	// Stop time of an alert muting rule, in Unix time format UTC. If set to 0, detectors that match this rule are muted indefinitely. The default value is 0. **read/write**

--- a/alertmuting/model_create_update_alert_muting_rule_request.go
+++ b/alertmuting/model_create_update_alert_muting_rule_request.go
@@ -15,8 +15,8 @@ type CreateUpdateAlertMutingRuleRequest struct {
 	Description string `json:"description,omitempty"`
 	// List of alert muting filters for this rule, in the form of a JSON array of alert muting filter objects. Each object is a set of conditions for an alert muting rule. Each object property (name-value pair)  specifies a dimension or custom property to match to alert events. **read/write**
 	Filters []*AlertMutingRuleFilter `json:"filters,omitempty"`
-	// Toggle if alerts should be sent once the muting period is over.  If not specified, defaults to true **read/write**
-	SendAlertsOnceMutingPeriodHasEnded bool `json:"sendAlertsOnceMutingPeriodHasEnded,omitempty"`
+	// Toggle if alerts should be sent once the muting period is over.  If not specified, defaults to false **read/write**
+	SendAlertsOnceMutingPeriodHasEnded bool `json:"sendAlertsOnceMutingPeriodHasEnded"`
 	// Starting time of an alert muting rule, in Unix time format UTC. If not specified, defaults to the current time. **read/write**.
 	StartTime int64 `json:"startTime,omitempty"`
 	// Stop time of an alert muting rule, in Unix time format UTC. If set to 0, detectors that match this rule are muted indefinitely. The default value is 0. **read/write**


### PR DESCRIPTION
The AlertMutingRule SendAlertsOnceMutingPeriodHasEnded currently has the
"omitempty" JSON tag. Because false is the boolean zero value, setting
SendAlertsOnceMutingPeriodHasEnded to false causes the field to be
omitted when marshaled as JSON. Since the API defaults this value to
true, it is not possible to set it to false using the Create or
UpdateAlertMutingRule functions.

Removing the "omitempty" tag will allow users to set this field to
false.

---

You can see a reproduction of the bug here https://go.dev/play/p/70cNPv6y7jV

The biggest drawback of this PR is that it changes the behavior of not explicitly setting `SendAlertsOnceMutingPeriodHasEnded`. Before, if the field was unset, the API would default the value to true. Now, leaving the value unset will result in `false` being sent to the API server. I think this is a reasonable tradeoff given that it was previously impossible to set the value to false, but let me know if you disagree.