### PR TITLE
Add `customMetricTypeDomains` field to the `GCPIntegration` struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.26.0 13 Jan 2023
+
+* Add `customMetricTypeDomains` field to the `GCPIntegration` struct [#180](https://github.com/signalfx/signalfx-go/pull/180)
+
 # 1.25.0 22 Nov 2022
 
 * Update list of Azure services [#175](https://github.com/signalfx/signalfx-go/pull/175), [#176](https://github.com/signalfx/signalfx-go/pull/176)

--- a/integration/model_gcp_integration.go
+++ b/integration/model_gcp_integration.go
@@ -32,6 +32,8 @@ type GCPIntegration struct {
 	PollRateMs int64     `json:"pollRate,omitempty"`
 	// Array of GCP services that you want SignalFx to monitor. SignalFx only supports certain services, and if you specify an unsupported one, you receive an API error. The supported services are: <br>   * appengine   * bigquery   * bigtable   * cloudfunctions   * cloudiot   * cloudsql   * cloudtasks   * compute   * container   * dataflow   * datastore   * firebasedatabase   * firebasehosting   * interconnect   * loadbalancing   * logging   * ml   * monitoring   * pubsub   * router   * serviceruntime   * spanner   * storage   * vpn
 	Services []GcpService `json:"services,omitempty"`
+	// A list of additional GCP service domain names that you want to monitor using Observability Cloud. Use this list to specify services that Observability Cloud doesn't support. If you specify an invalid name, the system responds to your API request with an HTTP response code <i>400</i>.
+	CustomMetricTypeDomains []string `json:"customMetricTypeDomains,omitempty"`
 	// List of GCP project that you want SignalFx to monitor, in the form of a JSON array of objects
 	ProjectServiceKeys []*GCPProject `json:"projectServiceKeys,omitempty"`
 	// When this value is set to true Observability Cloud will force usage of a quota from the project where metrics are stored. For this to work the service account provided for the project needs to be provided with serviceusage.services.use permission or Service Usage Consumer role in this project. When set to false default quota settings are used.


### PR DESCRIPTION
Hi folks! I'm going to use field `customMetricTypeDomains` which I've got from [the official docs](https://dev.splunk.com/observability/docs/integrations/gcp_integration_overview/#Request-body-for-POST-v2integration) in the Terraform provider [splunk-terraform/signalfx](https://github.com/splunk-terraform/terraform-provider-signalfx).
Issue: https://github.com/signalfx/signalfx-go/issues/181