### PR TITLE
add signalflow detach func

### DIFF
--- a/signalflow/client.go
+++ b/signalflow/client.go
@@ -292,6 +292,15 @@ func (c *Client) Execute(req *ExecuteRequest) (*Computation, error) {
 	return newComputation(c.ctx, c.registerChannel(req.Channel), c), nil
 }
 
+func (c *Client) Detach(req *DetachRequest) error {
+	// We are assuming that the detach request will always come from the same
+	// client that started it with the Execute method above, and thus the
+	// connection is still active (i.e. we don't need to call ensureInitialized
+	// here).  If the websocket connection does drop, all jobs started by that
+	// connection get detached/stopped automatically.
+	return c.sendMessage(req)
+}
+
 // Stop sends a job stop request message to the backend.  It does not wait for
 // jobs to actually be stopped.
 func (c *Client) Stop(req *StopRequest) error {

--- a/signalflow/computation.go
+++ b/signalflow/computation.go
@@ -411,6 +411,20 @@ func (c *Computation) IsFinished() bool {
 	return c.ctx.Err() != nil
 }
 
+// Detach the computation on the backend by using the channel name.
+func (c *Computation) Detach() error {
+	return c.DetachWithReason("")
+}
+
+// DetachWithReason detaches the computation with a given reason. This reason will
+// be reflected in the control message that signals the end of the job/channel
+func (c *Computation) DetachWithReason(reason string) error {
+	return c.client.Detach(&DetachRequest{
+		Reason:  reason,
+		Channel: c.channel.name,
+	})
+}
+
 // Stop the computation on the backend.
 func (c *Computation) Stop() error {
 	return c.StopWithReason("")


### PR DESCRIPTION
The stop job function is currently broken on the backend, this causes applications that use `Stop()` to leak jobs which leads to various problems. ex: https://github.com/signalfx/signalfx-k8s-metrics-adapter
The recommended way is to use `detach` func instead, which this PR adds.
cc: @kchengsf 
