### PR TITLE
Add detach to FakeBackend which now supports both, stop and detach

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,4 +37,4 @@ jobs:
           go install github.com/mauricelam/genny
           go install golang.org/x/tools/cmd/goimports
           go generate ./...
-          go test ./... -parallel 4 -timeout 2m
+          go test ./... -parallel 4 -timeout 4m


### PR DESCRIPTION
Previous https://github.com/signalfx/signalfx-go/pull/186 added support to detach, this PR adds the detach to the fakebackend which is used for testing in https://github.com/signalfx/signalfx-k8s-metrics-adapter/blob/main/internal/integration_test.go