### PR TITLE
fix: Close leaking goroutines when conn == nil

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -104,6 +104,7 @@ func Test_Close_DoesNotLeakGoroutines(t *testing.T) {
 	// This test compares goroutines before and after creating the client - let's wait for other goroutines to close first.
 	_ = waitForAllGoroutinesToDie(2, time.Second*2)
 	goroutinesBefore := runtime.NumGoroutine()
+	signalflow.ReconnectDelay = time.Millisecond * 200
 
 	clientsCount := 10
 	clients := make([]*signalflow.Client, clientsCount)
@@ -123,7 +124,7 @@ func Test_Close_DoesNotLeakGoroutines(t *testing.T) {
 	if goroutinesAfter != goroutinesBefore {
 		t.Logf("goroutinesAfter[%d] != goroutinesBefore[%d]\n", goroutinesAfter, goroutinesBefore)
 		_ = syscall.Kill(syscall.Getpid(), syscall.SIGQUIT) // send SIGQUIT to dump goroutines for easier debug
-		t.Fail()
+		t.Errorf("goroutinesAfter[%d] != goroutinesBefore[%d]\n", goroutinesAfter, goroutinesBefore)
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -3,13 +3,17 @@ package signalfx
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"runtime"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/signalfx/signalfx-go/chart"
+	"github.com/signalfx/signalfx-go/signalflow"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,7 +26,7 @@ var (
 )
 
 func fixture(path string) string {
-	b, err := ioutil.ReadFile("testdata/fixtures/" + path)
+	b, err := os.ReadFile("testdata/fixtures/" + path)
 	if err != nil {
 		panic(err)
 	}
@@ -74,7 +78,7 @@ func verifyRequest(t *testing.T, method string, expectToken bool, status int, pa
 		w.WriteHeader(status)
 		// Allow empty bodies
 		if resultPath != "" {
-			fmt.Fprintf(w, fixture(resultPath))
+			_, _ = fmt.Fprintf(w, fixture(resultPath))
 		}
 	}
 }
@@ -93,4 +97,80 @@ func TestPathHandling(t *testing.T) {
 	})
 	assert.NoError(t, err, "Unexpected error creating chart")
 	assert.Equal(t, "string", result.Name, "Name does not match")
+}
+
+func Test_Close_DoesNotLeakGoroutines(t *testing.T) {
+	// it can happen that there are still some dangling goroutines from other tests.
+	// This test compares goroutines before and after creating the client - let's wait for other goroutines to close first.
+	_ = waitForAllGoroutinesToDie(2, time.Second*2)
+	goroutinesBefore := runtime.NumGoroutine()
+
+	clientsCount := 10
+	clients := make([]*signalflow.Client, clientsCount)
+	for i := 0; i < clientsCount; i++ {
+		clients[i] = newClient(t)
+		go executeRequest(t, clients[i])
+	}
+
+	time.Sleep(time.Second) // I don't see a better way to wait for client to hang on sendMessage..
+
+	for i := 0; i < clientsCount; i++ {
+		clients[i].Close()
+	}
+
+	goroutinesAfter := waitForAllGoroutinesToDie(goroutinesBefore, time.Second*10)
+
+	if goroutinesAfter != goroutinesBefore {
+		t.Logf("goroutinesAfter[%d] != goroutinesBefore[%d]\n", goroutinesAfter, goroutinesBefore)
+		_ = syscall.Kill(syscall.Getpid(), syscall.SIGQUIT) // send SIGQUIT to dump goroutines for easier debug
+		t.Fail()
+	}
+}
+
+func newClient(t *testing.T) *signalflow.Client {
+	t.Helper()
+
+	client, err := signalflow.NewClient(
+		signalflow.StreamURLForRealm("invalidRealm"),
+		signalflow.StreamURL("wss://stream.invalidRealm.fakeSignalFX.com"),
+		signalflow.AccessToken("invalidToken"),
+		signalflow.WriteTimeout(time.Millisecond*100),
+		signalflow.MetadataTimeout(time.Millisecond*100),
+	)
+	if err != nil {
+		t.Fatalf("error when creating client: %s", err.Error())
+	}
+
+	return client
+}
+
+func executeRequest(t *testing.T, c *signalflow.Client) {
+	t.Helper()
+
+	_, err := c.Execute(&signalflow.ExecuteRequest{
+		Program:      "invalid | program",
+		Start:        time.Now(),
+		ResolutionMs: (time.Second * 15).Milliseconds(),
+		Immediate:    false,
+		MaxDelay:     time.Minute,
+	})
+
+	if err != nil {
+		t.Fatalf("error when executing request: %s", err.Error())
+	}
+}
+
+func waitForAllGoroutinesToDie(goroutinesBefore int, maxWaitTime time.Duration) int {
+	i := 0
+	sleepTime := time.Millisecond * 200
+	goroutinesAfter := runtime.NumGoroutine()
+	for goroutinesAfter != goroutinesBefore {
+		time.Sleep(sleepTime)
+		if sleepTime*time.Duration(i) == maxWaitTime {
+			break
+		}
+		i++
+		goroutinesAfter = runtime.NumGoroutine()
+	}
+	return goroutinesAfter
 }

--- a/signalflow/conn.go
+++ b/signalflow/conn.go
@@ -84,6 +84,14 @@ func (c *wsConn) Run() {
 
 			if c.ctx.Err() == context.Canceled {
 				log.Printf("Context cancelled, stop reconnecting.")
+				// if the conn is nil no one will drain outgoing messages when stopping
+				for msg := range c.outgoingTextMsgs {
+					msg.resultCh <- nil
+					//
+					if len(c.outgoingTextMsgs) == 0 {
+						close(c.outgoingTextMsgs)
+					}
+				}
 				return
 			}
 

--- a/signalflow/conn.go
+++ b/signalflow/conn.go
@@ -87,7 +87,6 @@ func (c *wsConn) Run() {
 				// if the conn is nil no one will drain outgoing messages when stopping
 				for msg := range c.outgoingTextMsgs {
 					msg.resultCh <- nil
-					//
 					if len(c.outgoingTextMsgs) == 0 {
 						close(c.outgoingTextMsgs)
 					}


### PR DESCRIPTION
## Problem

When the connection is not established (for example due to the wrong realm) `Client.Close()` leaves goroutines behind.

While testing, I have spawned 33 clients and closed 32 - this should leave me with just 2 goroutines but I have 34 instead.
![image](https://user-images.githubusercontent.com/179468/230619916-012c301c-9e16-41ea-96d0-a34bf6101e04.png)


## Details

- `signalflow.NewClient` spawns two goroutines:
  - `Client.run`
  - `wsConn.Run`
    - as long as the connection is not established it loops, trying to establish the connection
    - in case of context.Cancelled (triggered by Close()) it just leaves
- `Client.Execute` is called by the user
  - this calls `Client.sendMessage` and waits in `serializeAndWriteMessage` on one of:
    - `c.conn.OutgoingTextMessages() <- &outgoingMessage`
    - `return <-resultCh`

## Solution

### Fix closing of the client

- `wsConn.Run` can:
  - drain the `OutgoingTextMessages` to unblock `Client.serializeAndWriteMessage`
  - push `nil` error to `outgoingMessage.resultChan` to unblock `Client.serializeAndWriteMessage`
  - close `wsConn.outgoingMessage` to unblock shutting down in `wsConn.run`

### Refactor `NewClient`

I didn't take this path - random thoughts of other changes to fix the situation.

- do not spawn goroutines when initializing the client
- add possibility to initialize the client synchronously - let the user handle non retryable errors
- allow to execute the program only when there is a connection

## Testing

The scenario can be tested manually by:
- providing invalid realm
- running `client.ExecuteProgram`
- calling `client.Close`

I have provided a test `Test_Close_DoesNotLeakGoroutines` that simulates this situation and compares how many goroutines are before and after the test.
