### PR TITLE
fix organization model struct

### DIFF
--- a/organization/model_organization.go
+++ b/organization/model_organization.go
@@ -32,7 +32,7 @@ type Organization struct {
 	// The authentication key for the account that owns the organization.
 	AccountKey string `json:"accountKey,omitempty"`
 	// The renewal status for the account that owns the organization
-	AccountRenews string `json:"accountRenews,omitempty"`
+	AccountRenews bool `json:"accountRenews,omitempty"`
 	// Specifies a date and time after which the account that owns the organization becomes invalid, in Unix time UTC-relative.
 	AccountValidUntil int64 `json:"accountValidUntil,omitempty"`
 	// Specifies the number of datapoints per minute that the  organization can receive.


### PR DESCRIPTION
when making the following call, which returns the current organization:

```
result, err := s.sfxClient.GetOrganization(s.ctx, "")
```

It fails with the following error:

```
panic: json: cannot unmarshal bool into Go struct field Organization.accountRenews of type string
```

This patch changes the type of accountRenews to be a bool so that I can use the GetOrganization methods.