### PR TITLE
signalflow client: Handle receipt of duplicate info messages without crashing

### DIFF
--- a/signalflow/computation.go
+++ b/signalflow/computation.go
@@ -333,8 +333,9 @@ var ErrMetadataTimeout = errors.New("metadata value did not come in time")
 
 type asyncMetadata[T any] struct {
 	sync.Mutex
-	sig chan struct{}
-	val T
+	sig   chan struct{}
+	isSet bool
+	val   T
 }
 
 func (a *asyncMetadata[T]) ensureInit() {
@@ -349,7 +350,10 @@ func (a *asyncMetadata[T]) Set(val T) {
 	a.ensureInit()
 	a.Lock()
 	a.val = val
-	close(a.sig)
+	if !a.isSet {
+		close(a.sig)
+		a.isSet = true
+	}
 	a.Unlock()
 }
 


### PR DESCRIPTION
Certain types of jobs can cause the resolution info message to be sent twice for some reason, causing a panic on the close channel for the asyncMetadata.Set call