### PR TITLE
Deprecate writer package

### DIFF
--- a/writer/README.md
+++ b/writer/README.md
@@ -3,6 +3,10 @@
 See the [godoc](https://godoc.org/github.com/signalfx/signalfx-go/writer) for
 information on what they are and how to use them.
 
+> [!WARNING]  
+> `writer` package is **deprecated**.
+> Use OpenTelemetry Go instead.
+
 ## Compiling
 
 The buffer and writer are generated from a common template in the [`template`](./template)
@@ -13,4 +17,3 @@ install the code generation tool with `go get github.com/mauricelam/genny`.
 Also, `span_[writer|buffer]_test.go` is automatically generated from
 `datapoint_[writer|buffer]_test.go` by the same `go generate` command, so be
 sure to make changes in the datapoint test module.
-

--- a/writer/README.md
+++ b/writer/README.md
@@ -4,7 +4,7 @@ See the [godoc](https://godoc.org/github.com/signalfx/signalfx-go/writer) for
 information on what they are and how to use them.
 
 > [!WARNING]  
-> `writer` package is **deprecated** and no longer supported.
+> `writer` package is **deprecated** and will reach End of Support on October 18, 2024.
 > Use OpenTelemetry Go instead.
 
 ## Compiling

--- a/writer/README.md
+++ b/writer/README.md
@@ -4,7 +4,7 @@ See the [godoc](https://godoc.org/github.com/signalfx/signalfx-go/writer) for
 information on what they are and how to use them.
 
 > [!WARNING]  
-> `writer` package is **deprecated**.
+> `writer` package is **deprecated** and no longer supported.
 > Use OpenTelemetry Go instead.
 
 ## Compiling

--- a/writer/internal.go
+++ b/writer/internal.go
@@ -23,6 +23,8 @@
 // request at a time to ingest/gateway is probably not going to get enough
 // throughput, as usually the network and HTTP RTT is the bottleneck at that
 // point.
+//
+// Deprecated: Use OpenTelemetry Go instead.
 package writer
 
 //go:generate sh -c "cd template && ./gen.sh"


### PR DESCRIPTION
Our clients should use https://github.com/open-telemetry/opentelemetry-go or https://github.com/signalfx/splunk-otel-go instead of https://pkg.go.dev/github.com/signalfx/signalfx-go/writer. Let's make it clear.