### PR TITLE
Deprecate signalflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,6 @@
 
 This is a programmatic interface in Go for SignalFx's metadata and ingest APIs.
 
-# SignalFlow
-
-There is an **experimental** SignalFlow client in the `signalflow` directory.  An
-example of its use is in [signalflow/example].  For full documentation see the
-[godocs](https://godoc.org/github.com/signalfx/signalfx-go/signalflow).
-
 # Example
 
 ```

--- a/signalflow/README.md
+++ b/signalflow/README.md
@@ -3,6 +3,10 @@
 This is a client for [SignalFlow](https://dev.splunk.com/observability/docs/signalflow) that lets
 you stream and analyze metric data in real-time for your organization.
 
+> [!WARNING]  
+> `github.com/signalfx/signalfx-go/signalflow/v2` package is **deprecated**.
+> Use [`github.com/signalfx/signalflow-client-go/signalflow`](https://pkg.go.dev/github.com/signalfx/signalflow-client-go/signalflow) instead.
+
 ## Installation
 
 **You must use Go 1.19+ for the v2 of this client.**

--- a/signalflow/README.md
+++ b/signalflow/README.md
@@ -5,7 +5,7 @@ you stream and analyze metric data in real-time for your organization.
 
 > [!WARNING]  
 > `github.com/signalfx/signalfx-go/signalflow/v2` package is **deprecated**.
-> Use [`github.com/signalfx/signalflow-client-go/signalflow`](https://pkg.go.dev/github.com/signalfx/signalflow-client-go/signalflow) instead.
+> Use [`github.com/signalfx/signalflow-client-go/v2/signalflow`](https://pkg.go.dev/github.com/signalfx/signalflow-client-go/v2/signalflow) instead.
 
 ## Installation
 

--- a/signalflow/doc.go
+++ b/signalflow/doc.go
@@ -8,4 +8,6 @@
 // after a short delay.
 //
 // SignalFlow is documented at https://dev.splunk.com/observability/docs/signalflow/messages.
+//
+// Deprecated: Use github.com/signalfx/signalflow-client-go/signalflow instead.
 package signalflow

--- a/signalflow/doc.go
+++ b/signalflow/doc.go
@@ -9,5 +9,5 @@
 //
 // SignalFlow is documented at https://dev.splunk.com/observability/docs/signalflow/messages.
 //
-// Deprecated: Use github.com/signalfx/signalflow-client-go/signalflow instead.
+// Deprecated: Use github.com/signalfx/signalflow-client-go/v2/signalflow instead.
 package signalflow

--- a/signalflow/example/main.go
+++ b/signalflow/example/main.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/signalfx/signalfx-go/signalflow/v2"
+	"github.com/signalfx/signalfx-go/signalflow/v2" //nolint:staticcheck // Users should use github.com/signalfx/signalflow-client-go/signalflow instead.
 )
 
 func main() {

--- a/signalflow/go.mod
+++ b/signalflow/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: Use github.com/signalfx/signalflow-client-go/signalflow instead.
 module github.com/signalfx/signalfx-go/signalflow/v2
 
 go 1.19

--- a/signalflow/go.mod
+++ b/signalflow/go.mod
@@ -1,4 +1,4 @@
-// Deprecated: Use github.com/signalfx/signalflow-client-go/signalflow instead.
+// Deprecated: Use github.com/signalfx/signalflow-client-go/v2/signalflow instead.
 module github.com/signalfx/signalfx-go/signalflow/v2
 
 go 1.19


### PR DESCRIPTION
Deprecate signaflow module in favor of https://github.com/signalfx/signalflow-client-go/releases/tag/v2.3.0