### PR TITLE
detector: change detector model to allow sending empty array fields

### DIFF
--- a/detector/model_authorized_writers.go
+++ b/detector/model_authorized_writers.go
@@ -12,7 +12,7 @@ package detector
 // If your organization has the \"write permissions\" feature enabled, you can use this object to specify the user and team IDs that have write access to the object you're specifying.
 type AuthorizedWriters struct {
 	// An array of team IDs that have write access to this object
-	Teams []string `json:"teams,omitempty"`
+	Teams []string `json:"teams"`
 	// An array of user IDs that have write access to this object
-	Users []string `json:"users,omitempty"`
+	Users []string `json:"users"`
 }

--- a/detector/model_create_detector_request.go
+++ b/detector/model_create_detector_request.go
@@ -30,9 +30,9 @@ type CreateUpdateDetectorRequest struct {
 	// An array of *rules* that define aspects of an alert. These include the alert\\'s severity and the specification of how notifications are sent when the alert is triggered. Each rule is connected to a specific detect function in the programText property by the value of the label in its publish method. The connection is to a set of one or more notification directives and an severity indicator. A single condition can be used in multiple rules if different severity indicators are desired for different notification methods. <p> To see the properties for a rule, expand the definition of the rules array. What you see is the \"rules\" object that specifies a single rule.
 	Rules []*Rule `json:"rules,omitempty"`
 	// A an array of keywords that filters detectors by one of their fields. Use tags to indicate the state of a detector or its data source (for example, you can label a detector with a \"prod\" tag to indicate that it monitors a production environment).
-	Tags []string `json:"tags,omitempty"`
+	Tags []string `json:"tags"`
 	// IDs of teams associated with this detector. Teams associated with a detector can see the detector and its active alerts on the team's landing page in the web UI. The list of teams associated with a detector is independent of notification settings.  Teams specified in this field don\\'\\'t automatically get notified of new alerts, and teams that choose to get alerts do not have to display the detector on their team landing page in the web application.
-	Teams []string `json:"teams,omitempty"`
+	Teams []string `json:"teams"`
 	// Options that control the appearance of a detector in the SignalFx web UI.
 	VisualizationOptions *Visualization `json:"visualizationOptions,omitempty"`
 }

--- a/detector/model_detector.go
+++ b/detector/model_detector.go
@@ -45,9 +45,9 @@ type Detector struct {
 	ProgramText string  `json:"programText,omitempty"`
 	Rules       []*Rule `json:"rules,omitempty"`
 	// A an array of keywords that filters detectors by one of their fields. Use tags to indicate the state of a detector or its data source (for example, you can label a detector with a \"prod\" tag to indicate that it monitors a production environment).
-	Tags []string `json:"tags,omitempty"`
+	Tags []string `json:"tags"`
 	// IDs of teams associated with this detector. Teams associated with a detector can see the detector and its active alerts on the team's landing page in the web UI. The list of teams associated with a detector is independent of notification settings.  Teams specified in this field don\\'\\'t automatically get notified of new alerts, and teams that choose to get alerts do not have to display the detector on their team landing page in the web application.
-	Teams []string `json:"teams,omitempty"`
+	Teams []string `json:"teams"`
 	// Options that control the appearance of a detector in the SignalFx web UI.
 	VisualizationOptions *Visualization `json:"visualizationOptions,omitempty"`
 }


### PR DESCRIPTION
detector: change detector model to allow sending empty array fields

In detector API in order to remove all teams or tags from detector resource user has to send an empty array.