### PR TITLE
detector: extend detector model with detectorOrigin and parentDetectorId fields

### DIFF
--- a/detector/model_detector.go
+++ b/detector/model_detector.go
@@ -50,4 +50,8 @@ type Detector struct {
 	Teams []string `json:"teams"`
 	// Options that control the appearance of a detector in the SignalFx web UI.
 	VisualizationOptions *Visualization `json:"visualizationOptions,omitempty"`
+	// ID of the parent detector from which this detector is customized and created. This property is required for detectors with detectorOrigin of type AutoDetectCustomization.
+	ParentDetectorId string `json:"parentDetectorId,omitempty"`
+	// Indicates how a detector was created. The possible values are: Standard, AutoDetect, AutoDetectCustomization.You can only use Standard or AutoDetectCustomization to create custom detectors.
+	DetectorOrigin string `json:"detectorOrigin,omitempty"`
 }

--- a/testdata/fixtures/detector/get_success.json
+++ b/testdata/fixtures/detector/get_success.json
@@ -12,6 +12,8 @@
   "customProperties": "string",
   "description": "string",
   "id": "string",
+  "parentDetectorId": "string",
+  "detectorOrigin": "Standard",
   "labelResolutions": {
     "DetectorA": 3000,
     "DetectorB": 5000

--- a/testdata/fixtures/detector/search_success.json
+++ b/testdata/fixtures/detector/search_success.json
@@ -15,6 +15,8 @@
       "customProperties": "string",
       "description": "string",
       "id": "string",
+      "parentDetectorId": "string",
+      "detectorOrigin": "Standard",
       "labelResolutions": {
         "DetectorA": 3000,
         "DetectorB": 5000

--- a/testdata/fixtures/detector/update_success.json
+++ b/testdata/fixtures/detector/update_success.json
@@ -12,6 +12,8 @@
   "customProperties": "string",
   "description": "string",
   "id": "string",
+  "parentDetectorId": "string",
+  "detectorOrigin": "Standard",
   "labelResolutions": {
     "DetectorA": 3000,
     "DetectorB": 5000


### PR DESCRIPTION
detector: extend detector model with detectorOrigin and parentDetectorId fields