### PR TITLE
Check response code for errors

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -50,6 +50,13 @@ func (c *Client) GetIncidents(ctx context.Context, includeResolved bool, limit i
 	if resp != nil {
 		defer resp.Body.Close()
 	}
+	if resp.StatusCode != http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf(string(body))
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Check response code before unmarshaling response.Body. Sometimes the response code is 400 and the unmarshall errors out. This ensures that the errors are handled properly.