### PR TITLE
Return requestbody details in error response

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -64,6 +64,9 @@ func AsResponseError(err error) (*ResponseError, bool) {
 }
 
 func (re *ResponseError) Error() string {
+	if re.details != "" {
+		return fmt.Sprintf("route %q had issues with status code %d: %s", re.route, re.code, re.details)
+	}
 	return fmt.Sprintf("route %q had issues with status code %d", re.route, re.code)
 }
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -27,7 +27,7 @@ func TestRequestError(t *testing.T) {
 				route:   "/internal/heathz",
 				details: "failed due to overworked",
 			},
-			err: "route \"/internal/heathz\" had issues with status code 404",
+			err: "route \"/internal/heathz\" had issues with status code 404: failed due to overworked",
 		},
 		{
 			name: "missed details",


### PR DESCRIPTION
Right now, error response doesn't contain the actual error returned from the SingalFx API.
It only returns, for example `route "/v2/chart/<id>" failed with status code 400`.

This PR resolves this issue by sending the full response body incase of any error from SingalFx API.