### PR TITLE
Feature: Adding `CollectOnlyRecommendedOnly` to AWS Integration

### DIFF
--- a/integration/model_aws_cloud_watch_integration.go
+++ b/integration/model_aws_cloud_watch_integration.go
@@ -68,4 +68,7 @@ type AwsCloudWatchIntegration struct {
 	NamedToken string `json:"namedToken,omitempty"`
 	// If `true`, this property indicates that SignalFx should sync metrics and metadata from custom AWS namespaces only.
 	SyncCustomNamespacesOnly bool `json:"syncCustomNamespacesOnly,omitempty"`
+	// CollectOnlyRecommendedStats is used to enforce an integration to only collected the AWS' recommended statistics for the configured services.
+	// The current list of recommended stats are listed here: https://docs.splunk.com/observability/en/gdi/get-data-in/connect/aws/aws-recommended-stats.html
+	CollectOnlyRecommendedStats bool `json:"collectOnlyRecommendedStats,omitempty"`
 }


### PR DESCRIPTION
## Context

This is a new field that intended to be added into the terraform provider.

## Changes

- Added `CollectOnlyRecommendedStats` to AWS cloudwatch Integration