### PR TITLE
Retrieve all detectors

### DIFF
--- a/detector_test.go
+++ b/detector_test.go
@@ -108,6 +108,20 @@ func TestGetDetector(t *testing.T) {
 	assert.Equal(t, result.Name, "string", "Name does not match")
 }
 
+func TestGetDetectors(t *testing.T) {
+	teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/detector", verifyRequest(t, "GET", true, http.StatusOK, nil, "detector/get_detectors.json"))
+
+	result, err := client.GetDetectors(context.Background(), 1000, "", 0)
+	assert.NoError(t, err, "Unexpected error getting all detectors")
+	assert.Equal(t, len(result), 2, "Incorrect number of detectors returned")
+	assert.Equal(t, result[0].Id, "string", "ID does not match")
+	assert.Equal(t, result[0].ProgramText, "string", "Program text field does not match")
+	assert.Equal(t, result[1].Id, "string1", "ID does not match")
+}
+
 func TestGetMissingDetector(t *testing.T) {
 	teardown := setup()
 	defer teardown()

--- a/testdata/fixtures/detector/get_detectors.json
+++ b/testdata/fixtures/detector/get_detectors.json
@@ -1,0 +1,131 @@
+{
+  "count": 607,
+  "results": [
+    {
+      "authorizedWriters": {
+        "teams": [
+          "string"
+        ],
+        "users": [
+          "string"
+        ]
+      },
+      "created": 1533676829310,
+      "creator": "\"ZZZZZZZZZZZ\" if the system created the detector",
+      "customProperties": "string",
+      "description": "string",
+      "id": "string",
+      "parentDetectorId": "string",
+      "detectorOrigin": "Standard",
+      "labelResolutions": {
+        "DetectorA": 2000,
+        "DetectorB": 2000
+      },
+      "lastUpdated": 1533676829310,
+      "lastUpdatedBy": "string",
+      "locked": true,
+      "maxDelay": 60000,
+      "name": "string",
+      "overMTSLimit": true,
+      "programText": "string",
+      "rules": [
+        {
+          "description": "string",
+          "detectLabel": "string",
+          "disabled": true,
+          "notifications": [
+            {
+              "channel": "limit-notifications",
+              "credentialId": "ZZZZZZZAAAA",
+              "type": "Slack"
+            }
+          ],
+          "parameterizedBody": "string",
+          "parameterizedSubject": "string",
+          "runbookUrl": "string",
+          "severity": "Critical"
+        }
+      ],
+      "tags": [
+        "string"
+      ],
+      "teams": [
+        "string"
+      ],
+      "visualizationOptions": {
+        "disableSampling": true,
+        "showDataMarkers": true,
+        "showEventLines": true,
+        "time": {
+          "end": 0,
+          "range": 0,
+          "start": 0,
+          "type": "absolute"
+        }
+      }
+    },
+    {
+      "authorizedWriters": {
+        "teams": [
+          "string"
+        ],
+        "users": [
+          "string"
+        ]
+      },
+      "created": 1533676829319,
+      "creator": "\"AAAAAAAAAA\" if the system created the detector",
+      "customProperties": "string",
+      "description": "string",
+      "id": "string1",
+      "parentDetectorId": "string",
+      "detectorOrigin": "Standard",
+      "labelResolutions": {
+        "DetectorA": 3000,
+        "DetectorB": 5000
+      },
+      "lastUpdated": 1533676829319,
+      "lastUpdatedBy": "string",
+      "locked": true,
+      "maxDelay": 60000,
+      "name": "string",
+      "overMTSLimit": true,
+      "programText": "string",
+      "rules": [
+        {
+          "description": "string",
+          "detectLabel": "string",
+          "disabled": true,
+          "notifications": [
+            {
+              "channel": "limit-notifications",
+              "credentialId": "ZZZZZZZAAAA",
+              "type": "Slack"
+            }
+          ],
+          "parameterizedBody": "string",
+          "parameterizedSubject": "string",
+          "runbookUrl": "string",
+          "severity": "Critical"
+        }
+      ],
+      "tags": [
+        "string"
+      ],
+      "teams": [
+        "string"
+      ],
+      "visualizationOptions": {
+        "disableSampling": true,
+        "showDataMarkers": true,
+        "showEventLines": true,
+        "time": {
+          "end": 0,
+          "range": 0,
+          "start": 0,
+          "type": "absolute"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This merge request adds code that sends a GET request to the `/v2/detector` endpoint documented in the following page: https://dev.splunk.com/observability/reference/api/detectors/latest#endpoint-retrieve-detectors-query

This follows the same pattern used in the other endpoints for retrieving objects with the signalfx API. Changes have been tested locally to insure that it works as intended.