### PR TITLE
Added support for Splunk Platform Notification

### DIFF
--- a/notification/model_notification.go
+++ b/notification/model_notification.go
@@ -48,6 +48,8 @@ func (n *Notification) UnmarshalJSON(data []byte) error {
 		n.Value = &WebhookNotification{}
 	case "XMatters":
 		n.Value = &XMattersNotification{}
+	case "SplunkPlatform":
+		n.Value = &SplunkPlatformNotification{}
 	default:
 		return fmt.Errorf("Unknown notification type %v", typ.Type)
 	}

--- a/notification/model_splunk_platform_notification.go
+++ b/notification/model_splunk_platform_notification.go
@@ -1,0 +1,10 @@
+package notification
+
+type SplunkPlatformNotification struct {
+	// Tells SignalFx which system it should use to send the notification. For an Splunk Platform notification, this is always \"SplunkPlatform\".
+	Type string `json:"type"`
+	// Tells SignalFX the HTTP Event Collector (HEC) URI for your Splunk platform instance
+	Url string `json:"url"`
+	//Enter the HTTP Event Collector token that allows access to your Splunk platform instance
+	HecToken string `json:"hecToken"`
+}

--- a/notification/model_splunk_platform_notification.go
+++ b/notification/model_splunk_platform_notification.go
@@ -1,7 +1,7 @@
 package notification
 
 type SplunkPlatformNotification struct {
-	// Tells SignalFx which system it should use to send the notification. For an Splunk Platform notification, this is always \"SplunkPlatform\".
+	// Type sets which system to use to send the notification. For a Splunk Platform notification, this is always \"SplunkPlatform\".
 	Type string `json:"type"`
 	// Tells SignalFX the HTTP Event Collector (HEC) URI for your Splunk platform instance
 	Url string `json:"url"`

--- a/notification/model_splunk_platform_notification.go
+++ b/notification/model_splunk_platform_notification.go
@@ -3,7 +3,7 @@ package notification
 type SplunkPlatformNotification struct {
 	// Type sets which system to use to send the notification. For a Splunk Platform notification, this is always \"SplunkPlatform\".
 	Type string `json:"type"`
-	// Tells SignalFX the HTTP Event Collector (HEC) URI for your Splunk platform instance
+	// Url sets the HTTP Event Collector (HEC) URI for your Splunk platform instance
 	Url string `json:"url"`
 	//Enter the HTTP Event Collector token that allows access to your Splunk platform instance
 	HecToken string `json:"hecToken"`

--- a/notification/model_splunk_platform_notification.go
+++ b/notification/model_splunk_platform_notification.go
@@ -5,6 +5,6 @@ type SplunkPlatformNotification struct {
 	Type string `json:"type"`
 	// Url sets the HTTP Event Collector (HEC) URI for your Splunk platform instance
 	Url string `json:"url"`
-	//Enter the HTTP Event Collector token that allows access to your Splunk platform instance
+	//HecToken sets the HTTP Event Collector token that allows access to your Splunk platform instance
 	HecToken string `json:"hecToken"`
 }


### PR DESCRIPTION
I was unable to fetch detectors from my org as one of the detectors was of the type [SplunkPlatform](https://docs.splunk.com/observability/en/admin/notif-services/splunkplatform.html) and the signalfx-go module does not support it right now.