### PR TITLE
Added support for Splunk Platform Integration and Notification

### DIFF
--- a/integration/model_splunk_platform_integration.go
+++ b/integration/model_splunk_platform_integration.go
@@ -1,0 +1,30 @@
+package integration
+
+type SplunkPlatformIntegration struct {
+	// The creation date and time for the integration object, in Unix time UTC-relative. The system sets this value, and you can't modify it.
+	Created int64 `json:"created,omitempty"`
+	// Splunk Observability assigned user ID of the user that created the integration object. If the system created the object, the value is \"AAAAAAAAAA\". The system sets this value, and you can't modify it.
+	Creator string `json:"creator,omitempty"`
+	//Name of the user that created the integration
+	CreatedByName string `json:"createdByName,omitempty"`
+	//Type of service that this integration represents, in the form of an enumerated string, always "SplunkPlatform"
+	Type Type `json:"type"`
+	// Flag that indicates the state of the integration object. If  `true`, the integration is enabled. If `false`, the integration is disabled, and you must enable it by setting \"enabled\" to `true` in a **PUT** request that updates the object. <br> **NOTE:** Splunk Observability always sets the flag to `true` when you call  **POST** `/integration` to create an integration.
+	Enabled bool `json:"enabled"`
+	//HTTP Event Collector token that allows access to your Splunk platform instance
+	HecToken string `json:"hecToken,omitempty"`
+	//Splunk Observability assignedID of an integration you create in the web UI or API. Use this property to retrieve an integration using the **GET**, **PUT**, or **DELETE** `/integration/{id}` endpoints or the **GET** `/integration/validate{id}/` endpoint, as described in this topic.
+	Id string `json:"id,omitempty"`
+	// The last time the integration was updated, in Unix time UTC-relative. This value is \"read-only\".
+	LastUpdated int64 `json:"lastUpdated,omitempty"`
+	//Splunk Observability assigned ID of the last user who updated the integration. If the last update was by the system, the value is \"AAAAAAAAAA\". This value is \"read-only\".
+	LastUpdatedBy string `json:"lastUpdatedBy,omitempty"`
+	//Name of the user that last updated the integration
+	LastUpdatedByName string `json:"lastUpdatedByName,omitempty"`
+	// A human-readable label for the integration. This property helps you identify a specific integration when you're using multiple integrations for the same service.
+	Name string `json:"name,omitempty"`
+	//Customize the Splunk platform alert payload using Handlebars syntax
+	PayloadTemplate string `json:"payloadTemplate,omitempty"`
+	//Specify the HTTP Event Collector (HEC) URI for your Splunk platform instance
+	Url string `json:"url,omitempty"`
+}

--- a/notification/model_notification.go
+++ b/notification/model_notification.go
@@ -48,6 +48,8 @@ func (n *Notification) UnmarshalJSON(data []byte) error {
 		n.Value = &WebhookNotification{}
 	case "XMatters":
 		n.Value = &XMattersNotification{}
+	case "SplunkPlatform":
+		n.Value = &SplunkPlatformNotification{}
 	default:
 		return fmt.Errorf("Unknown notification type %v", typ.Type)
 	}

--- a/notification/model_splunk_platform_notification.go
+++ b/notification/model_splunk_platform_notification.go
@@ -1,0 +1,10 @@
+package notification
+
+type SplunkPlatformNotification struct {
+	// Tells SignalFx which system it should use to send the notification. For an Splunk Platform notification, this is always \"SplunkPlatform\".
+	Type string `json:"type"`
+	// Tells SignalFX the HTTP Event Collector (HEC) URI for your Splunk platform instance
+	Url string `json:"url"`
+	//Enter the HTTP Event Collector token that allows access to your Splunk platform instance
+	HecToken string `json:"hecToken"`
+}

--- a/notification/model_splunk_platform_notification.go
+++ b/notification/model_splunk_platform_notification.go
@@ -1,7 +1,7 @@
 package notification
 
 type SplunkPlatformNotification struct {
-	// Tells SignalFx which system it should use to send the notification. For an Splunk Platform notification, this is always \"SplunkPlatform\".
+	// Type sets which system to use to send the notification. For a Splunk Platform notification, this is always \"SplunkPlatform\".
 	Type string `json:"type"`
 	// Tells SignalFX the HTTP Event Collector (HEC) URI for your Splunk platform instance
 	Url string `json:"url"`

--- a/notification/model_splunk_platform_notification.go
+++ b/notification/model_splunk_platform_notification.go
@@ -4,7 +4,7 @@ type SplunkPlatformNotification struct {
 	// Type sets which system to use to send the notification. For a Splunk Platform notification, this is always \"SplunkPlatform\".
 	Type string `json:"type"`
 	// Url sets the HTTP Event Collector (HEC) URI for your Splunk platform instance
-	Url string `json:"url,omitempty"`
+	Url string `json:"url"`
 	//HecToken sets the HTTP Event Collector token that allows access to your Splunk platform instance
-	HecToken string `json:"hecToken,omitempty"`
+	HecToken string `json:"hecToken"`
 }

--- a/notification/model_splunk_platform_notification.go
+++ b/notification/model_splunk_platform_notification.go
@@ -3,7 +3,7 @@ package notification
 type SplunkPlatformNotification struct {
 	// Type sets which system to use to send the notification. For a Splunk Platform notification, this is always \"SplunkPlatform\".
 	Type string `json:"type"`
-	// Tells SignalFX the HTTP Event Collector (HEC) URI for your Splunk platform instance
+	// Url sets the HTTP Event Collector (HEC) URI for your Splunk platform instance
 	Url string `json:"url"`
 	//Enter the HTTP Event Collector token that allows access to your Splunk platform instance
 	HecToken string `json:"hecToken"`

--- a/notification/model_splunk_platform_notification.go
+++ b/notification/model_splunk_platform_notification.go
@@ -4,7 +4,7 @@ type SplunkPlatformNotification struct {
 	// Type sets which system to use to send the notification. For a Splunk Platform notification, this is always \"SplunkPlatform\".
 	Type string `json:"type"`
 	// Url sets the HTTP Event Collector (HEC) URI for your Splunk platform instance
-	Url string `json:"url"`
+	Url string `json:"url,omitempty"`
 	//HecToken sets the HTTP Event Collector token that allows access to your Splunk platform instance
-	HecToken string `json:"hecToken"`
+	HecToken string `json:"hecToken,omitempty"`
 }

--- a/notification/model_splunk_platform_notification.go
+++ b/notification/model_splunk_platform_notification.go
@@ -5,6 +5,6 @@ type SplunkPlatformNotification struct {
 	Type string `json:"type"`
 	// Url sets the HTTP Event Collector (HEC) URI for your Splunk platform instance
 	Url string `json:"url"`
-	//Enter the HTTP Event Collector token that allows access to your Splunk platform instance
+	//HecToken sets the HTTP Event Collector token that allows access to your Splunk platform instance
 	HecToken string `json:"hecToken"`
 }


### PR DESCRIPTION
I was unable to fetch detectors from my org as one of the detectors was of the type [SplunkPlatform](https://docs.splunk.com/observability/en/admin/notif-services/splunkplatform.html) and the signalfx-go module does not support it right now.

I have also added support form the Splunk Platform Integration.