### PR TITLE
Added support for Splunk Platform Integration and Notification

### DIFF
--- a/integration/model_splunk_platform_integration.go
+++ b/integration/model_splunk_platform_integration.go
@@ -1,0 +1,30 @@
+package integration
+
+type SplunkPlatformIntegration struct {
+	// The creation date and time for the integration object, in Unix time UTC-relative. The system sets this value, and you can't modify it.
+	Created int64 `json:"created,omitempty"`
+	// Splunk Observability assigned user ID of the user that created the integration object. If the system created the object, the value is \"AAAAAAAAAA\". The system sets this value, and you can't modify it.
+	Creator string `json:"creator,omitempty"`
+	//Name of the user that created the integration
+	CreatedByName string `json:"createdByName,omitempty"`
+	//Type of service that this integration represents, in the form of an enumerated string, always "SplunkPlatform"
+	Type Type `json:"type"`
+	// Flag that indicates the state of the integration object. If  `true`, the integration is enabled. If `false`, the integration is disabled, and you must enable it by setting \"enabled\" to `true` in a **PUT** request that updates the object. <br> **NOTE:** Splunk Observability always sets the flag to `true` when you call  **POST** `/integration` to create an integration.
+	Enabled bool `json:"enabled"`
+	//HTTP Event Collector token that allows access to your Splunk platform instance
+	HecToken string `json:"hecToken,omitempty"`
+	//Splunk Observability assignedID of an integration you create in the web UI or API. Use this property to retrieve an integration using the **GET**, **PUT**, or **DELETE** `/integration/{id}` endpoints or the **GET** `/integration/validate{id}/` endpoint, as described in this topic.
+	Id string `json:"id,omitempty"`
+	// The last time the integration was updated, in Unix time UTC-relative. This value is \"read-only\".
+	LastUpdated int64 `json:"lastUpdated,omitempty"`
+	//Splunk Observability assigned ID of the last user who updated the integration. If the last update was by the system, the value is \"AAAAAAAAAA\". This value is \"read-only\".
+	LastUpdatedBy string `json:"lastUpdatedBy,omitempty"`
+	//Name of the user that last updated the integration
+	LastUpdatedByName string `json:"lastUpdatedByName,omitempty"`
+	// A human-readable label for the integration. This property helps you identify a specific integration when you're using multiple integrations for the same service.
+	Name string `json:"name,omitempty"`
+	//Customize the Splunk platform alert payload using Handlebars syntax
+	PayloadTemplate string `json:"payloadTemplate,omitempty"`
+	//Specify the HTTP Event Collector (HEC) URI for your Splunk platform instance
+	Url string `json:"url,omitempty"`
+}

--- a/integration/model_type.go
+++ b/integration/model_type.go
@@ -8,29 +8,31 @@
  */
 
 package integration
+
 // Type : Service that this integration object configures in SignalFx. This is an enumerated string that describes the service. SignalFx processes requests based on the type specified.<br> In addition, the \"type\" property controls OpenApi 3 validation. If you use a model for one service but specify the type for another service, OAS 3 validation programs may reject your request. <br> **For data collection services, the allowed values are:**<br>    * AWSCloudWatch   * Azure   * GCP   * NewRelic  **For SSO integrations, the allowed values are:**<br>   * ADFS   * AzureAD   * Bitium   * GoogleSaml   * Okta   * OneLogin   * PingOne  **For alerting services, the allowed values are:**<br>   * BigPanda   * Office365   * Opsgenie   * PagerDuty   * ServiceNow   * Slack   * VictorOps   * Webhook   * XMatters (note the capital \"X\")  ## Viewing request or response bodies To see the request or response body format, find it in the following dropdown box. To see a full list, click the down arrow and navigate with the vertical scrollbar.
 type Type string
 
 // List of Type
 const (
-	ADFS Type = "ADFS"
+	ADFS            Type = "ADFS"
 	AWS_CLOUD_WATCH Type = "AWSCloudWatch"
-	AZURE Type = "Azure"
-	AZURE_AD Type = "AzureAD"
-	BITIUM Type = "Bitium"
-	BIG_PANDA Type = "BigPanda"
-	GCP Type = "GCP"
-	GOOGLE_SAML Type = "GoogleSaml"
-	OFFICE365 Type = "Office365"
-	OKTA Type = "Okta"
-	ONE_LOGIN Type = "OneLogin"
-	OPSGENIE Type = "Opsgenie"
-	PAGER_DUTY Type = "PagerDuty"
-	PING_ONE Type = "PingOne"
-	NEW_RELIC Type = "NewRelic"
-	SERVICE_NOW Type = "ServiceNow"
-	SLACK Type = "Slack"
-	VICTOR_OPS Type = "VictorOps"
-	WEBHOOK Type = "Webhook"
-	X_MATTERS Type = "XMatters"
+	AZURE           Type = "Azure"
+	AZURE_AD        Type = "AzureAD"
+	BITIUM          Type = "Bitium"
+	BIG_PANDA       Type = "BigPanda"
+	GCP             Type = "GCP"
+	GOOGLE_SAML     Type = "GoogleSaml"
+	OFFICE365       Type = "Office365"
+	OKTA            Type = "Okta"
+	ONE_LOGIN       Type = "OneLogin"
+	OPSGENIE        Type = "Opsgenie"
+	PAGER_DUTY      Type = "PagerDuty"
+	PING_ONE        Type = "PingOne"
+	NEW_RELIC       Type = "NewRelic"
+	SERVICE_NOW     Type = "ServiceNow"
+	SLACK           Type = "Slack"
+	SPLUNK_PLATFORM Type = "SplunkPlatform"
+	VICTOR_OPS      Type = "VictorOps"
+	WEBHOOK         Type = "Webhook"
+	X_MATTERS       Type = "XMatters"
 )

--- a/notification/model_notification.go
+++ b/notification/model_notification.go
@@ -48,6 +48,8 @@ func (n *Notification) UnmarshalJSON(data []byte) error {
 		n.Value = &WebhookNotification{}
 	case "XMatters":
 		n.Value = &XMattersNotification{}
+	case "SplunkPlatform":
+		n.Value = &SplunkPlatformNotification{}
 	default:
 		return fmt.Errorf("unknown notification type %q", typ.Type)
 	}

--- a/notification/model_notification_test.go
+++ b/notification/model_notification_test.go
@@ -135,6 +135,14 @@ func TestNotificationUnmarshaJSON(t *testing.T) {
 			}},
 			errVal: "",
 		},
+		{
+			name:  "SplunkPlatform",
+			input: `{"type":"SplunkPlatform"}`,
+			expect: &Notification{Type: "SplunkPlatform", Value: &SplunkPlatformNotification{
+				Type: "SplunkPlatform",
+			}},
+			errVal: "",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/notification/model_splunk_platform_notification.go
+++ b/notification/model_splunk_platform_notification.go
@@ -1,0 +1,8 @@
+package notification
+
+type SplunkPlatformNotification struct {
+	// Type sets which system to use to send the notification. For a Splunk Platform notification, this is always \"SplunkPlatform\".
+	Type string `json:"type"`
+	// Splunk Platform-supplied credential ID that Splunk Observability uses to authenticate the notification with the Splunk Platform system. Get this value from your Splunk Platform account settings.
+	CredentialId string `json:"credentialId"`
+}

--- a/testdata/fixtures/detector/get_detectors.json
+++ b/testdata/fixtures/detector/get_detectors.json
@@ -101,6 +101,10 @@
               "channel": "limit-notifications",
               "credentialId": "ZZZZZZZAAAA",
               "type": "Slack"
+            },
+            {
+              "credentialId": "string",
+              "type": "SplunkPlatform"
             }
           ],
           "parameterizedBody": "string",


### PR DESCRIPTION
I was unable to fetch detectors from my org as notification on one of the detectors was of the type [SplunkPlatform](https://docs.splunk.com/observability/en/admin/notif-services/splunkplatform.html) and the signalfx-go module does not support it right now.

I have also added support form the Splunk Platform Integration.