### PR TITLE
Fix GetOrganization to not require OrgID

### DIFF
--- a/organization.go
+++ b/organization.go
@@ -18,9 +18,9 @@ const OrganizationAPIURL = "/v2/organization"
 const OrganizationMemberAPIURL = "/v2/organization/member"
 const OrganizationMembersAPIURL = "/v2/organization/members"
 
-// GetOrganization gets an organization.
-func (c *Client) GetOrganization(ctx context.Context, id string) (*organization.Organization, error) {
-	resp, err := c.doRequest(ctx, "GET", OrganizationAPIURL+"/"+id, nil, nil)
+// GetOrganization gets an organization associated with the token in use by the client.
+func (c *Client) GetOrganization(ctx context.Context) (*organization.Organization, error) {
+	resp, err := c.doRequest(ctx, "GET", OrganizationAPIURL, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/organization.go
+++ b/organization.go
@@ -19,7 +19,7 @@ const OrganizationMemberAPIURL = "/v2/organization/member"
 const OrganizationMembersAPIURL = "/v2/organization/members"
 
 // GetOrganization gets an organization associated with the token in use by the client.
-func (c *Client) GetOrganization(ctx context.Context) (*organization.Organization, error) {
+func (c *Client) GetOrganization(ctx context.Context, _ string) (*organization.Organization, error) {
 	resp, err := c.doRequest(ctx, "GET", OrganizationAPIURL, nil, nil)
 	if err != nil {
 		return nil, err

--- a/organization_test.go
+++ b/organization_test.go
@@ -18,7 +18,7 @@ func TestGetOrganization(t *testing.T) {
 
 	mux.HandleFunc("/v2/organization", verifyRequest(t, "GET", true, http.StatusOK, nil, "organization/get_success.json"))
 
-	_, err := client.GetOrganization(context.Background())
+	_, err := client.GetOrganization(context.Background(), "")
 	assert.NoError(t, err, "Unexpected error getting organization")
 }
 

--- a/organization_test.go
+++ b/organization_test.go
@@ -16,11 +16,10 @@ func TestGetOrganization(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/organization/string", verifyRequest(t, "GET", true, http.StatusOK, nil, "organization/get_success.json"))
+	mux.HandleFunc("/v2/organization", verifyRequest(t, "GET", true, http.StatusOK, nil, "organization/get_success.json"))
 
-	result, err := client.GetOrganization(context.Background(), "string")
+	_, err := client.GetOrganization(context.Background())
 	assert.NoError(t, err, "Unexpected error getting organization")
-	assert.Equal(t, result.Id, "string", "Id does not match")
 }
 
 func TestGetMissingOrganization(t *testing.T) {


### PR DESCRIPTION
This PR fixes a bug in the `GetOrganization` method. The Splunk Observability API does not accept an OrgID as part of the path, it infers the org from the token and endpoint. I tested this code locally and it works with this change.