### PR TITLE
ALEN-2463 Add cc and bcc fields to Email notification model.

### DIFF
--- a/notification/model_email_notification.go
+++ b/notification/model_email_notification.go
@@ -6,4 +6,8 @@ type EmailNotification struct {
 	Type string `json:"type"`
 	// The destination address for the notification email. SignalFx doesn't validate this address, so you must ensure it's correct before you use it. SignalFx may not store invalid values, and it may try to  send notification email that doesn't have an address. In either case, the notification won't be delivered.
 	Email string `json:"email"`
+	// Optional CC recipient email addresses.
+	Cc []string `json:"cc,omitempty"`
+	// Optional BCC recipient email addresses.
+	Bcc []string `json:"bcc,omitempty"`
 }

--- a/notification/model_notification_test.go
+++ b/notification/model_notification_test.go
@@ -48,6 +48,17 @@ func TestNotificationUnmarshaJSON(t *testing.T) {
 			errVal: "",
 		},
 		{
+			name: "Email with cc and bcc",
+			input: `{"type":"Email","email":"alerts@example.com","cc":["oncall@example.com","ops@example.com"],"bcc":["audit@example.com"]}`,
+			expect: &Notification{Type: "Email", Value: &EmailNotification{
+				Type:  "Email",
+				Email: "alerts@example.com",
+				Cc:    []string{"oncall@example.com", "ops@example.com"},
+				Bcc:   []string{"audit@example.com"},
+			}},
+			errVal: "",
+		},
+		{
 			name:  "Jira",
 			input: `{"type":"Jira"}`,
 			expect: &Notification{Type: "Jira", Value: &JiraNotification{


### PR DESCRIPTION
Support optional cc/bcc recipient lists on detector email notifications (ALEN-2198).