### PR TITLE
Stabilize writer buffer tests

### DIFF
--- a/writer/datapoint_writer_test.go
+++ b/writer/datapoint_writer_test.go
@@ -126,16 +126,22 @@ func TestDatapointWriter(t *testing.T) {
 			ts.Writer.Start(ts.Ctx)
 
 			inputCount := 100000
+			nextDrain := ts.Writer.MaxBuffered / 2
 
 			i := 0
 			var batch []*datapoint.Datapoint
 			for i <= inputCount {
 				if i == inputCount || len(batch) == inBatchSize {
-					// Slow it down a bit so it doesn't wraparound the buffer
-					time.Sleep(100 * time.Nanosecond)
 					ts.Input <- batch
 					batch = nil
-					time.Sleep(100 * time.Nanosecond)
+					if i >= nextDrain {
+						// Drain periodically so wraparound is not dependent on scheduler timing.
+						require.Eventually(t, func() bool {
+							return atomic.LoadInt64(&ts.Writer.TotalSent) >= int64(i) &&
+								atomic.LoadInt64(&ts.Writer.TotalInFlight) == 0
+						}, 3*time.Second, time.Millisecond)
+						nextDrain = i + ts.Writer.MaxBuffered/2
+					}
 				}
 				batch = append(batch, &datapoint.Datapoint{Meta: map[interface{}]interface{}{"i": i}})
 				i++

--- a/writer/span_writer_test.go
+++ b/writer/span_writer_test.go
@@ -124,16 +124,22 @@ func TestSpanWriter(t *testing.T) {
 			ts.Writer.Start(ts.Ctx)
 
 			inputCount := 100000
+			nextDrain := ts.Writer.MaxBuffered / 2
 
 			i := 0
 			var batch []*trace.Span
 			for i <= inputCount {
 				if i == inputCount || len(batch) == inBatchSize {
-					// Slow it down a bit so it doesn't wraparound the buffer
-					time.Sleep(100 * time.Nanosecond)
 					ts.Input <- batch
 					batch = nil
-					time.Sleep(100 * time.Nanosecond)
+					if i >= nextDrain {
+						// Drain periodically so wraparound is not dependent on scheduler timing.
+						require.Eventually(t, func() bool {
+							return atomic.LoadInt64(&ts.Writer.TotalSent) >= int64(i) &&
+								atomic.LoadInt64(&ts.Writer.TotalInFlight) == 0
+						}, 3*time.Second, time.Millisecond)
+						nextDrain = i + ts.Writer.MaxBuffered/2
+					}
 				}
 				batch = append(batch, &trace.Span{Meta: map[interface{}]interface{}{"i": i}})
 				i++


### PR DESCRIPTION
## Summary

- Replace scheduler-dependent 100ns sleeps in the datapoint and span writer ring-buffer tests.
- Periodically wait for submitted items to be sent and in-flight requests to drain before continuing.
- Keep exercising ring-buffer wraparound without allowing parallel test scheduling to cause unintended overwrites.

## Root cause

Under Go 1.25 and 1.26 on GitHub Actions, parallel test execution could submit input faster than sender goroutines were scheduled. The 3,000-entry test buffer then overwrote items, making the "without losing anything" assertion depend on scheduler timing.

## Impact

This is a test-only stabilization. Production writer behavior is unchanged.

## Validation

- `go test ./... -parallel 4 -timeout 10m`
- Repeated the previously failing datapoint and span writer cases under parallel execution.
